### PR TITLE
refactor: change insertMessage to upsertMessage in the userMessage insertion

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -243,7 +243,7 @@ export async function POST(request: Request) {
               responseMessages: response.messages,
             });
             if (isLastMessageUserMessage) {
-              await chatRepository.insertMessage({
+              await chatRepository.upsertMessage({
                 threadId: thread!.id,
                 model: chatModel?.model ?? null,
                 role: "user",

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -27,6 +27,7 @@ const staticModels = {
     }),
   },
   google: {
+    "gemini-2.0-flash-lite": google("gemini-2.0-flash-lite"),
     "gemini-2.5-flash": google("gemini-2.5-flash-preview-04-17"),
     "gemini-2.5-pro": google("gemini-2.5-pro-preview-05-06"),
   },
@@ -52,6 +53,7 @@ const staticModels = {
 
 const staticUnsupportedModels = new Set([
   staticModels.openai["o4-mini"],
+  staticModels.google["gemini-2.0-flash-lite"],
   staticModels.ollama["gemma3:1b"],
   staticModels.ollama["gemma3:4b"],
   staticModels.ollama["gemma3:12b"],


### PR DESCRIPTION
Problem: In the changeModel flow, retries caused deletion of assistant messages, leading to attempts to re-insert existing user messages. This triggered a "duplicate key value violates unique constraint 'chat_message_pkey'" error.

Solution: Replaced insertMessage with upsertMessage to handle existing records gracefully via update instead of failing on insert.