### PR TITLE
feat: Lazy Chat Title Generation: Save Empty Title First, Then Generate and Upsert in Parallel

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -41,10 +41,7 @@ import {
   filterMcpServerCustomizations,
   workflowToVercelAITools,
 } from "./shared.chat";
-import {
-  generateTitleFromUserMessageAction,
-  rememberMcpServerCustomizationsAction,
-} from "./actions";
+import { rememberMcpServerCustomizationsAction } from "./actions";
 import { getSession } from "auth/server";
 import { colorize } from "consola/utils";
 import { isVercelAIWorkflowTool } from "app-types/workflow";
@@ -81,14 +78,10 @@ export async function POST(request: Request) {
     let thread = await chatRepository.selectThreadDetails(id);
 
     if (!thread) {
-      const title = await generateTitleFromUserMessageAction({
-        message,
-        model,
-      });
       const newThread = await chatRepository.insertThread({
         id,
         projectId: projectId ?? null,
-        title,
+        title: "",
         userId: session.user.id,
       });
       thread = await chatRepository.selectThreadDetails(newThread.id);

--- a/src/app/api/chat/title/route.ts
+++ b/src/app/api/chat/title/route.ts
@@ -1,47 +1,56 @@
-import { convertToCoreMessages, smoothStream, streamText } from "ai";
-import { selectThreadWithMessagesAction } from "../actions";
+import { smoothStream, streamText } from "ai";
+
 import { customModelProvider } from "lib/ai/models";
-import { SUMMARIZE_PROMPT } from "lib/ai/prompts";
-import logger from "logger";
+import { CREATE_THREAD_TITLE_PROMPT } from "lib/ai/prompts";
+import globalLogger from "logger";
 import { ChatModel } from "app-types/chat";
-import { redirect, RedirectType } from "next/navigation";
+import { chatRepository } from "lib/db/repository";
+import { getSession } from "auth/server";
+import { colorize } from "consola/utils";
+
+const logger = globalLogger.withDefaults({
+  message: colorize("blackBright", `Title API: `),
+});
 
 export async function POST(request: Request) {
   try {
     const json = await request.json();
-    const { threadId, chatModel } = json as {
-      threadId: string;
+    const {
+      chatModel,
+      message = "hello",
+      threadId,
+      projectId,
+    } = json as {
       chatModel?: ChatModel;
+      message: string;
+      projectId?: string;
+      threadId: string;
     };
 
-    const thread = await selectThreadWithMessagesAction(threadId);
-
-    if (!thread) redirect("/", RedirectType.replace);
-
-    const messages = convertToCoreMessages(
-      thread.messages
-        .map((v) => ({
-          content: "",
-          role: v.role,
-          parts: v.parts,
-        }))
-        .concat({
-          content: "",
-          parts: [
-            {
-              type: "text",
-              text: "Generate a system prompt based on the conversation so far according to the rules.",
-            },
-          ],
-          role: "user",
-        }),
+    logger.debug(
+      `chatModel: ${chatModel?.provider}/${chatModel?.model}, threadId: ${threadId}, projectId: ${projectId}`,
     );
+    logger.debug(`message: ${message}`);
+
+    const session = await getSession();
+    if (!session) {
+      return new Response("Unauthorized", { status: 401 });
+    }
 
     const result = streamText({
       model: customModelProvider.getModel(chatModel),
-      system: SUMMARIZE_PROMPT,
+      system: CREATE_THREAD_TITLE_PROMPT,
       experimental_transform: smoothStream({ chunking: "word" }),
-      messages,
+      prompt: message,
+      onFinish: (ctx) => {
+        console.log(`title: ${ctx.text}`);
+        chatRepository.upsertThread({
+          id: threadId,
+          title: ctx.text,
+          projectId,
+          userId: session.user.id,
+        });
+      },
     });
 
     return result.toDataStreamResponse();

--- a/src/app/store/index.ts
+++ b/src/app/store/index.ts
@@ -16,6 +16,7 @@ export interface AppState {
   toolChoice: "auto" | "none" | "manual";
   allowedMcpServers?: Record<string, AllowedMCPServer>;
   allowedAppDefaultToolkit?: AppDefaultToolkit[];
+  generatingTitleThreadIds: string[];
   threadMentions: {
     [threadId: string]: ChatMention[];
   };
@@ -51,6 +52,7 @@ export interface AppDispatch {
 const initialState: AppState = {
   threadList: [],
   projectList: [],
+  generatingTitleThreadIds: [],
   threadMentions: {},
   mcpList: [],
   workflowToolList: [],

--- a/src/components/layouts/app-header.tsx
+++ b/src/components/layouts/app-header.tsx
@@ -21,6 +21,7 @@ import Link from "next/link";
 import { useShallow } from "zustand/shallow";
 import { getShortcutKeyList, Shortcuts } from "lib/keyboard-shortcuts";
 import { useTranslations } from "next-intl";
+import { TextShimmer } from "ui/text-shimmer";
 
 export function AppHeader() {
   const t = useTranslations();
@@ -142,13 +143,15 @@ export function AppHeader() {
 }
 
 function ThreadDropdownComponent() {
-  const [threadList, currentThreadId, projectList] = appStore(
-    useShallow((state) => [
-      state.threadList,
-      state.currentThreadId,
-      state.projectList,
-    ]),
-  );
+  const [threadList, currentThreadId, projectList, generatingTitleThreadIds] =
+    appStore(
+      useShallow((state) => [
+        state.threadList,
+        state.currentThreadId,
+        state.projectList,
+        state.generatingTitleThreadIds,
+      ]),
+    );
   const currentThread = useMemo(() => {
     return threadList.find((thread) => thread.id === currentThreadId);
   }, [threadList, currentThreadId]);
@@ -183,14 +186,29 @@ function ThreadDropdownComponent() {
         threadId={currentThread.id}
         beforeTitle={currentThread.title}
       >
-        <Button
-          variant="ghost"
-          className="data-[state=open]:bg-input! hover:text-foreground cursor-pointer flex gap-1 items-center px-2 py-1 rounded-md hover:bg-accent"
-        >
-          <p className="truncate max-w-60 min-w-0">{currentThread.title}</p>
+        <div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                className="data-[state=open]:bg-input! hover:text-foreground cursor-pointer flex gap-1 items-center px-2 py-1 rounded-md hover:bg-accent"
+              >
+                {generatingTitleThreadIds.includes(currentThread.id) ? (
+                  <TextShimmer className="truncate max-w-60 min-w-0 mr-1">
+                    {currentThread.title || "New Chat"}
+                  </TextShimmer>
+                ) : (
+                  <p className="truncate max-w-60 min-w-0 mr-1">
+                    {currentThread.title || "New Chat"}
+                  </p>
+                )}
 
-          <ChevronDown size={14} />
-        </Button>
+                <ChevronDown size={14} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{currentThread.title || "New Chat"}</TooltipContent>
+          </Tooltip>
+        </div>
       </ThreadDropdown>
     </div>
   );

--- a/src/components/layouts/app-sidebar-threads.tsx
+++ b/src/components/layouts/app-sidebar-threads.tsx
@@ -33,6 +33,8 @@ import { handleErrorWithToast } from "ui/shared-toast";
 import { useMemo, useState } from "react";
 
 import { useTranslations } from "next-intl";
+import { TextShimmer } from "ui/text-shimmer";
+import { Tooltip, TooltipContent, TooltipTrigger } from "ui/tooltip";
 
 type ThreadGroup = {
   label: string;
@@ -45,8 +47,12 @@ export function AppSidebarThreads() {
   const mounted = useMounted();
   const router = useRouter();
   const t = useTranslations("Layout");
-  const [storeMutate, currentThreadId] = appStore(
-    useShallow((state) => [state.mutate, state.currentThreadId]),
+  const [storeMutate, currentThreadId, generatingTitleThreadIds] = appStore(
+    useShallow((state) => [
+      state.mutate,
+      state.currentThreadId,
+      state.generatingTitleThreadIds,
+    ]),
   );
   // State to track if expanded view is active
   const [isExpanded, setIsExpanded] = useState(false);
@@ -225,18 +231,35 @@ export function AppSidebarThreads() {
                           beforeTitle={thread.title}
                         >
                           <div className="flex items-center data-[state=open]:bg-input! group-hover/thread:bg-input! rounded-lg">
-                            <SidebarMenuButton
-                              asChild
-                              className="group-hover/thread:bg-transparent!"
-                              isActive={currentThreadId === thread.id}
-                            >
-                              <Link
-                                href={`/chat/${thread.id}`}
-                                className="flex items-center"
-                              >
-                                <p className="truncate ">{thread.title}</p>
-                              </Link>
-                            </SidebarMenuButton>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <SidebarMenuButton
+                                  asChild
+                                  className="group-hover/thread:bg-transparent!"
+                                  isActive={currentThreadId === thread.id}
+                                >
+                                  <Link
+                                    href={`/chat/${thread.id}`}
+                                    className="flex items-center"
+                                  >
+                                    {generatingTitleThreadIds.includes(
+                                      thread.id,
+                                    ) ? (
+                                      <TextShimmer className="truncate min-w-0">
+                                        {thread.title || "New Chat"}
+                                      </TextShimmer>
+                                    ) : (
+                                      <p className="truncate min-w-0">
+                                        {thread.title || "New Chat"}
+                                      </p>
+                                    )}
+                                  </Link>
+                                </SidebarMenuButton>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                {thread.title || "New Chat"}
+                              </TooltipContent>
+                            </Tooltip>
 
                             <SidebarMenuAction className="data-[state=open]:bg-input data-[state=open]:opacity-100 opacity-0 group-hover/thread:opacity-100">
                               <MoreHorizontal />

--- a/src/components/prompt-input.tsx
+++ b/src/components/prompt-input.tsx
@@ -177,7 +177,7 @@ export default function PromptInput({
   return (
     <div className="max-w-3xl mx-auto fade-in animate-in">
       <div className="z-10 mx-auto w-full max-w-3xl relative">
-        <fieldset className="flex w-full min-w-0 max-w-full flex-col px-2">
+        <fieldset className="flex w-full min-w-0 max-w-full flex-col px-4">
           <div className="ring-8 ring-muted/60 overflow-hidden rounded-4xl backdrop-blur-sm transition-all duration-200 bg-muted/60 relative flex w-full flex-col cursor-text z-10 items-stretch focus-within:bg-muted hover:bg-muted focus-within:ring-muted hover:ring-muted">
             {mentions.length > 0 && (
               <div className="bg-input rounded-b-sm rounded-t-3xl p-3 flex flex-col gap-4">

--- a/src/hooks/queries/use-generate-thread-title.ts
+++ b/src/hooks/queries/use-generate-thread-title.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { appStore } from "@/app/store";
+import { useCompletion } from "@ai-sdk/react";
+import { ChatModel } from "app-types/chat";
+import { useCallback, useEffect } from "react";
+import { mutate } from "swr";
+import { safe } from "ts-safe";
+
+export function useGenerateThreadTitle(option: {
+  threadId: string;
+  projectId?: string;
+  chatModel?: ChatModel;
+}) {
+  const { complete, completion } = useCompletion({
+    api: "/api/chat/title",
+  });
+
+  const generateTitle = useCallback(
+    (message: string) => {
+      const { threadId, chatModel, projectId } = option;
+      if (appStore.getState().generatingTitleThreadIds.includes(threadId))
+        return;
+      appStore.setState((prev) => ({
+        generatingTitleThreadIds: [...prev.generatingTitleThreadIds, threadId],
+      }));
+      safe(() =>
+        complete("", {
+          body: {
+            message,
+            threadId,
+            chatModel: chatModel ?? appStore.getState().chatModel,
+            projectId,
+          },
+        }),
+      )
+        .ifOk(() => mutate("threads"))
+        .watch(() => {
+          appStore.setState((prev) => ({
+            generatingTitleThreadIds: prev.generatingTitleThreadIds.filter(
+              (v) => v !== threadId,
+            ),
+          }));
+        });
+    },
+    [option],
+  );
+
+  useEffect(() => {
+    const title = completion.trim();
+    if (title) {
+      appStore.setState((prev) => {
+        if (prev.threadList.some((v) => v.id !== option.threadId)) {
+          return {
+            threadList: [
+              {
+                id: option.threadId,
+                title,
+                userId: "",
+                createdAt: new Date(),
+                projectId: option.projectId ?? null,
+              },
+              ...prev.threadList,
+            ],
+          };
+        }
+
+        return {
+          threadList: prev.threadList.map((v) =>
+            v.id === option.threadId ? { ...v, title } : v,
+          ),
+        };
+      });
+    }
+  }, [completion, option.threadId]);
+
+  return generateTitle;
+}

--- a/src/lib/db/pg/repositories/chat-repository.pg.ts
+++ b/src/lib/db/pg/repositories/chat-repository.pg.ts
@@ -201,6 +201,21 @@ export const pgChatRepository: ChatRepository = {
       .returning();
     return result;
   },
+  upsertThread: async (
+    thread: Omit<ChatThread, "createdAt">,
+  ): Promise<ChatThread> => {
+    const [result] = await db
+      .insert(ChatThreadSchema)
+      .values(thread)
+      .onConflictDoUpdate({
+        target: [ChatThreadSchema.id],
+        set: {
+          title: thread.title,
+        },
+      })
+      .returning();
+    return result;
+  },
 
   deleteThread: async (id: string): Promise<void> => {
     await db

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -155,6 +155,10 @@ export type ChatRepository = {
 
   deleteThread(id: string): Promise<void>;
 
+  upsertThread(
+    thread: PartialBy<Omit<ChatThread, "createdAt">, "projectId" | "userId">,
+  ): Promise<ChatThread>;
+
   insertMessage(message: Omit<ChatMessage, "createdAt">): Promise<ChatMessage>;
   upsertMessage(message: Omit<ChatMessage, "createdAt">): Promise<ChatMessage>;
 


### PR DESCRIPTION
- Added `useGenerateThreadTitle` hook to handle title generation for threads.
- Integrated title generation in `ProjectPage`, `ChatBot`, and `AppSidebarThreads` components.
- Updated API routes to support title generation and upsert functionality for threads.
- Enhanced UI to indicate when a thread title is being generated using `TextShimmer` and tooltips.
- Modified state management to track threads currently generating titles.