### PR TITLE
fix(scripts): parse openai compatible on windows

### DIFF
--- a/scripts/parse-openai-compatiable.ts
+++ b/scripts/parse-openai-compatiable.ts
@@ -1,12 +1,13 @@
 import * as fs from "fs";
 import * as path from "path";
+import { pathToFileURL } from "node:url";
 import "load-env";
 import logger from "logger";
 import { openaiCompatibleModelsSafeParse } from "lib/ai/create-openai-compatiable";
 
 const ROOT = process.cwd();
 const FILE_NAME = "openai-compatible.config.ts";
-const CONFIG_PATH = path.join(ROOT, FILE_NAME);
+const CONFIG_PATH = pathToFileURL(path.join(ROOT, FILE_NAME)).href;
 
 async function load() {
   try {


### PR DESCRIPTION
## Description

Ensure the openAI parsing script works as expected

## Related issues

Fixes https://github.com/cgoinglove/better-chatbot/issues/163

## Testing

1. Fill some data for openAI compatible server
2. Run `pnpm openai-compatiable:parse`
3. assert everything works as expected