### PR TITLE
refactor: Comprehensive UI/UX Improvements for #226 Feature

### DIFF
--- a/src/app/(chat)/agent/[id]/loading.tsx
+++ b/src/app/(chat)/agent/[id]/loading.tsx
@@ -1,10 +1,13 @@
 import { getTranslations } from "next-intl/server";
-import { EditItemLoading } from "@/components/ui/edit-item-loading";
+import { EditShareableLoading } from "@/components/edit-shareable-loading";
 
 export default async function AgentLoading() {
   const t = await getTranslations();
 
   return (
-    <EditItemLoading title={t("Common.editAgent")} showGenerateButton={true} />
+    <EditShareableLoading
+      title={t("Common.editAgent")}
+      showGenerateButton={true}
+    />
   );
 }

--- a/src/app/(chat)/workflow/page.tsx
+++ b/src/app/(chat)/workflow/page.tsx
@@ -10,7 +10,7 @@ import useSWR, { mutate } from "swr";
 import { fetcher } from "lib/utils";
 import { Skeleton } from "ui/skeleton";
 import { BackgroundPaths } from "ui/background-paths";
-import { ItemCard } from "@/components/ui/item-card";
+import { ShareableCard } from "@/components/shareable-card";
 import {
   DBEdge,
   DBNode,
@@ -29,6 +29,7 @@ import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "ui/dialog";
 import { WorkflowGreeting } from "@/components/workflow/workflow-greeting";
+import { notify } from "lib/notify";
 
 const createWithExample = async (exampleWorkflow: {
   workflow: Partial<DBWorkflow>;
@@ -112,7 +113,10 @@ export default function WorkflowPage() {
   };
 
   const deleteWorkflow = async (workflowId: string) => {
-    if (!confirm(t("Workflow.deleteConfirm"))) return;
+    const ok = await notify.confirm({
+      description: t("Workflow.deleteConfirm"),
+    });
+    if (!ok) return;
 
     try {
       const response = await fetch(`/api/workflow/${workflowId}`, {
@@ -204,7 +208,7 @@ export default function WorkflowPage() {
                   <Skeleton key={index} className="w-full h-[196px]" />
                 ))
             : myWorkflows?.map((workflow) => (
-                <ItemCard
+                <ShareableCard
                   key={workflow.id}
                   type="workflow"
                   item={workflow}
@@ -227,7 +231,7 @@ export default function WorkflowPage() {
 
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
             {sharedWorkflows?.map((workflow) => (
-              <ItemCard
+              <ShareableCard
                 key={workflow.id}
                 type="workflow"
                 item={workflow}

--- a/src/components/agent/agents-list.tsx
+++ b/src/components/agent/agents-list.tsx
@@ -8,13 +8,14 @@ import { Button } from "ui/button";
 import { Plus, ArrowUpRight } from "lucide-react";
 import Link from "next/link";
 import { BackgroundPaths } from "ui/background-paths";
-import { ItemCard } from "@/components/ui/item-card";
 import { useBookmark } from "@/hooks/use-bookmark";
 import { useInvalidateAgents } from "@/hooks/queries/use-agents";
 import { toast } from "sonner";
 import useSWR from "swr";
 import { fetcher } from "lib/utils";
-import { Visibility } from "../ui/item-actions";
+import { Visibility } from "@/components/shareable-actions";
+import { ShareableCard } from "@/components/shareable-card";
+import { notify } from "lib/notify";
 
 interface AgentsListProps {
   initialMyAgents: AgentSummary[];
@@ -75,7 +76,10 @@ export function AgentsList({
   };
 
   const deleteAgent = async (agentId: string) => {
-    if (!confirm(t("Agent.deleteConfirm"))) return;
+    const ok = await notify.confirm({
+      description: t("Agent.deleteConfirm"),
+    });
+    if (!ok) return;
 
     try {
       const response = await fetch(`/api/agent/${agentId}`, {
@@ -98,8 +102,8 @@ export function AgentsList({
       <div className="flex justify-between items-center">
         <h1 className="text-2xl font-bold">{t("Layout.agents")}</h1>
         <Link href="/agent/new">
-          <Button>
-            <Plus className="size-4 mr-2" />
+          <Button variant="ghost">
+            <Plus />
             {t("Agent.newAgent")}
           </Button>
         </Link>
@@ -136,7 +140,7 @@ export function AgentsList({
           </Link>
 
           {myAgents.map((agent) => (
-            <ItemCard
+            <ShareableCard
               key={agent.id}
               type="agent"
               item={agent}
@@ -157,7 +161,7 @@ export function AgentsList({
 
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {sharedAgents.map((agent) => (
-            <ItemCard
+            <ShareableCard
               key={agent.id}
               type="agent"
               item={agent}
@@ -167,7 +171,7 @@ export function AgentsList({
             />
           ))}
           {sharedAgents.length === 0 && (
-            <Card className="col-span-full">
+            <Card className="col-span-full bg-transparent border-none">
               <CardHeader className="text-center py-12">
                 <CardTitle>{t("Agent.noSharedAgents")}</CardTitle>
                 <CardDescription>

--- a/src/components/agent/edit-agent.tsx
+++ b/src/components/agent/edit-agent.tsx
@@ -24,7 +24,6 @@ import {
   WandSparklesIcon,
   Bookmark,
   BookmarkCheck,
-  Trash2,
 } from "lucide-react";
 import { Button } from "ui/button";
 import {
@@ -39,7 +38,7 @@ import { Textarea } from "ui/textarea";
 import { ScrollArea } from "ui/scroll-area";
 import { Skeleton } from "ui/skeleton";
 import { TextShimmer } from "ui/text-shimmer";
-import { ItemActions, Visibility } from "ui/item-actions";
+import { ShareableActions, Visibility } from "@/components/shareable-actions";
 import { GenerateAgentDialog } from "./generate-agent-dialog";
 import { AgentIconPicker } from "./agent-icon-picker";
 import { AgentToolSelector } from "./agent-tool-selector";
@@ -47,6 +46,7 @@ import {
   RandomDataGeneratorExample,
   WeatherExample,
 } from "lib/ai/agent/example";
+import { notify } from "lib/notify";
 
 const defaultConfig = (): PartialBy<
   Omit<Agent, "createdAt" | "updatedAt" | "userId">,
@@ -220,7 +220,10 @@ export default function EditAgent({
   const deleteAgent = useCallback(async () => {
     if (!initialAgent?.id) return;
 
-    if (!confirm(t("Agent.deleteConfirm"))) return;
+    const ok = await notify.confirm({
+      description: t("Agent.deleteConfirm"),
+    });
+    if (!ok) return;
 
     try {
       await fetcher(`/api/agent/${initialAgent.id}`, {
@@ -364,7 +367,7 @@ export default function EditAgent({
 
                 {/* Visibility dropdown - only for owners */}
                 {isOwner && (
-                  <ItemActions
+                  <ShareableActions
                     type="agent"
                     visibility={agent.visibility || "private"}
                     isOwner={true}
@@ -511,16 +514,15 @@ export default function EditAgent({
         </div>
 
         {hasEditAccess && (
-          <div className={cn("flex justify-between", false && "hidden")}>
+          <div className={cn("flex justify-end gap-2")}>
             {/* Delete button - only for owners */}
             {initialAgent && isOwner && (
               <Button
-                className="mt-2"
-                variant="destructive"
+                className="mt-2 hover:text-destructive"
+                variant="ghost"
                 onClick={deleteAgent}
                 disabled={isLoading}
               >
-                <Trash2 className="size-4 mr-2" />
                 {t("Common.delete")}
               </Button>
             )}

--- a/src/components/agent/edit-agent.tsx
+++ b/src/components/agent/edit-agent.tsx
@@ -245,41 +245,36 @@ export default function EditAgent({
     setIsBookmarked(!isBookmarked);
   }, [initialAgent?.id, isBookmarked, toggleBookmark]);
 
-  const handleGenerateAgent = useCallback(
-    (generatedData: any) => {
-      objectFlow(generatedData).forEach((data, key) => {
-        setAgent((prev) => {
-          if (key === "name") {
-            return { name: data as string };
-          }
-          if (key === "description") {
-            return { description: data as string };
-          }
-          if (key === "instructions") {
-            textareaRef.current?.scrollTo({
-              top: textareaRef.current?.scrollHeight,
-            });
-            return {
-              instructions: {
-                ...prev.instructions,
-                systemPrompt: data as string,
-              },
-            };
-          }
-          if (key === "role") {
-            return {
-              instructions: {
-                ...prev.instructions,
-                role: data as string,
-              },
-            };
-          }
-          return prev;
-        });
+  const handleAgentChange = useCallback((generatedData: any) => {
+    if (textareaRef.current) {
+      textareaRef.current.scrollTo({
+        top: textareaRef.current.scrollHeight,
       });
-    },
-    [setAgent],
-  );
+    }
+    setAgent((prev) => {
+      return objectFlow(generatedData).map((data, key) => {
+        if (key === "name") {
+          return data;
+        }
+        if (key === "description") {
+          return data;
+        }
+        if (key === "instructions") {
+          return {
+            ...prev.instructions,
+            systemPrompt: data as string,
+          };
+        }
+        if (key === "role") {
+          return {
+            ...prev.instructions,
+            role: data as string,
+          };
+        }
+        return prev;
+      });
+    });
+  }, []);
 
   const isLoadingTool = useMemo(() => {
     return isMcpLoading || isWorkflowLoading;
@@ -542,7 +537,7 @@ export default function EditAgent({
       <GenerateAgentDialog
         open={openGenerateAgentDialog}
         onOpenChange={setOpenGenerateAgentDialog}
-        onGenerated={handleGenerateAgent}
+        onAgentChange={handleAgentChange}
         onToolsGenerated={assignToolsByNames}
       />
     </ScrollArea>

--- a/src/components/agent/edit-agent.tsx
+++ b/src/components/agent/edit-agent.tsx
@@ -252,27 +252,28 @@ export default function EditAgent({
       });
     }
     setAgent((prev) => {
-      return objectFlow(generatedData).map((data, key) => {
+      const update: Partial<Agent> = {};
+      objectFlow(generatedData).forEach((data, key) => {
         if (key === "name") {
-          return data;
+          update.name = data as string;
         }
         if (key === "description") {
-          return data;
+          update.description = data as string;
         }
         if (key === "instructions") {
-          return {
+          update.instructions = {
             ...prev.instructions,
             systemPrompt: data as string,
           };
         }
         if (key === "role") {
-          return {
+          update.instructions = {
             ...prev.instructions,
             role: data as string,
           };
         }
-        return prev;
       });
+      return { ...prev, ...update };
     });
   }, []);
 

--- a/src/components/agent/generate-agent-dialog.tsx
+++ b/src/components/agent/generate-agent-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import { experimental_useObject } from "@ai-sdk/react";
 import { ChatModel } from "app-types/chat";
@@ -23,14 +23,14 @@ import { appStore } from "@/app/store";
 interface GenerateAgentDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onGenerated: (data: any) => void;
+  onAgentChange: (data: any) => void;
   onToolsGenerated?: (tools: string[]) => void;
 }
 
 export function GenerateAgentDialog({
   open,
   onOpenChange,
-  onGenerated,
+  onAgentChange,
   onToolsGenerated,
 }: GenerateAgentDialogProps) {
   const t = useTranslations();
@@ -40,7 +40,7 @@ export function GenerateAgentDialog({
   const [generateAgentPrompt, setGenerateAgentPrompt] = useState("");
   const [submittedPrompt, setSubmittedPrompt] = useState("");
 
-  const { submit, isLoading } = experimental_useObject({
+  const { submit, isLoading, object } = experimental_useObject({
     api: "/api/agent/ai",
     schema: AgentGenerateSchema,
     onFinish(event) {
@@ -48,7 +48,7 @@ export function GenerateAgentDialog({
         handleErrorWithToast(event.error);
       }
       if (event.object) {
-        onGenerated(event.object);
+        onAgentChange(event.object);
         if (event.object.tools && onToolsGenerated) {
           onToolsGenerated(event.object.tools);
         }
@@ -70,6 +70,12 @@ export function GenerateAgentDialog({
     setGenerateAgentPrompt(""); // Clear textarea immediately after submit
     // Don't close dialog immediately - will close in onFinish
   };
+
+  useEffect(() => {
+    if (object && isLoading) {
+      onAgentChange(object);
+    }
+  }, [object, isLoading, onAgentChange]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/edit-shareable-loading.tsx
+++ b/src/components/edit-shareable-loading.tsx
@@ -1,14 +1,14 @@
 import { Skeleton } from "ui/skeleton";
 
-interface EditItemLoadingProps {
+interface EditShareableLoadingProps {
   title?: string;
   showGenerateButton?: boolean;
 }
 
-export function EditItemLoading({
+export function EditShareableLoading({
   title,
   showGenerateButton = false,
-}: EditItemLoadingProps) {
+}: EditShareableLoadingProps) {
   return (
     <div className="h-full w-full relative">
       <div className="z-10 relative flex flex-col gap-4 px-8 pt-8 pb-14 max-w-3xl h-full mx-auto">

--- a/src/components/layouts/app-sidebar-agents.tsx
+++ b/src/components/layouts/app-sidebar-agents.tsx
@@ -27,7 +27,6 @@ import { appStore } from "@/app/store";
 import { useRouter } from "next/navigation";
 import { ChatMention } from "app-types/chat";
 import { BACKGROUND_COLORS, EMOJI_DATA } from "lib/const";
-import { Separator } from "ui/separator";
 
 const DISPLAY_LIMIT = 5; // Number of agents to show when collapsed
 
@@ -36,8 +35,7 @@ export function AppSidebarAgents() {
   const t = useTranslations();
   const router = useRouter();
   const [expanded, setExpanded] = useState(false);
-  const { agents, myAgents, bookmarkedAgents, sharedAgents, isLoading } =
-    useAgents({ limit: 50 }); // Increase limit since we're not artificially limiting display
+  const { agents, sharedAgents, isLoading } = useAgents({ limit: 50 }); // Increase limit since we're not artificially limiting display
 
   const handleAgentClick = useCallback(
     (id: string) => {
@@ -140,154 +138,80 @@ export function AppSidebarAgents() {
             <>
               <div
                 className={
-                  expanded ? "max-h-[300px] w-full overflow-y-auto" : "w-full"
+                  expanded ? "max-h-[200px] w-full overflow-y-auto" : "w-full"
                 }
               >
                 <div className="flex flex-col gap-1">
-                  {(expanded
-                    ? myAgents
-                    : myAgents.slice(0, DISPLAY_LIMIT)
-                  )?.map((agent, i) => {
-                    return (
-                      <SidebarMenu
-                        key={agent.id}
-                        className="group/agent mr-0 w-full"
-                      >
-                        <SidebarMenuItem
-                          className="px-2 cursor-pointer w-full"
-                          onClick={() => handleAgentClick(agent.id)}
+                  {(expanded ? agents : agents.slice(0, DISPLAY_LIMIT))?.map(
+                    (agent, i) => {
+                      return (
+                        <SidebarMenu
+                          key={agent.id}
+                          className="group/agent mr-0 w-full"
                         >
-                          <SidebarMenuButton
-                            asChild
-                            className="data-[state=open]:bg-input! w-full"
+                          <SidebarMenuItem
+                            className="px-2 cursor-pointer w-full"
+                            onClick={() => handleAgentClick(agent.id)}
                           >
-                            <div className="flex gap-1 w-full min-w-0">
-                              <div
-                                className="p-1 rounded-full ring-2 ring-border bg-background"
-                                style={{
-                                  backgroundColor:
-                                    agent.icon?.style?.backgroundColor ||
-                                    BACKGROUND_COLORS[
-                                      i % BACKGROUND_COLORS.length
-                                    ],
-                                }}
-                              >
-                                <Avatar className="size-3.5">
-                                  <AvatarImage
-                                    src={
-                                      agent.icon?.value ||
-                                      EMOJI_DATA[i % EMOJI_DATA.length]
-                                    }
-                                  />
-                                  <AvatarFallback className="bg-transparent">
-                                    {agent.name[0]}
-                                  </AvatarFallback>
-                                </Avatar>
-                              </div>
-
-                              <div className="flex items-center min-w-0 w-full">
-                                <p className="truncate">{agent.name}</p>
-                              </div>
-                              <div
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  e.preventDefault();
-                                }}
-                              >
-                                <AgentDropdown
-                                  agent={agent}
-                                  side="right"
-                                  align="start"
-                                >
-                                  <SidebarMenuAction className="data-[state=open]:bg-input! data-[state=open]:opacity-100  opacity-0 group-hover/agent:opacity-100 mr-2">
-                                    <MoreHorizontal className="size-4" />
-                                  </SidebarMenuAction>
-                                </AgentDropdown>
-                              </div>
-                            </div>
-                          </SidebarMenuButton>
-                        </SidebarMenuItem>
-                      </SidebarMenu>
-                    );
-                  })}
-
-                  {bookmarkedAgents.length > 0 && expanded && (
-                    <>
-                      <Separator className="my-1" />
-                      {bookmarkedAgents.map((agent, i) => {
-                        return (
-                          <SidebarMenu
-                            key={agent.id}
-                            className="group/agent mr-0 w-full"
-                          >
-                            <SidebarMenuItem
-                              className="px-2 cursor-pointer w-full"
-                              onClick={() => handleAgentClick(agent.id)}
+                            <SidebarMenuButton
+                              asChild
+                              className="data-[state=open]:bg-input! w-full"
                             >
-                              <SidebarMenuButton
-                                asChild
-                                className="data-[state=open]:bg-input! w-full"
-                              >
-                                <div className="flex gap-1 w-full min-w-0">
-                                  <div
-                                    className="p-1 rounded-full ring-2 ring-border bg-background"
-                                    style={{
-                                      backgroundColor:
-                                        agent.icon?.style?.backgroundColor ||
-                                        BACKGROUND_COLORS[
-                                          (i + myAgents.length) %
-                                            BACKGROUND_COLORS.length
-                                        ],
-                                    }}
-                                  >
-                                    <Avatar className="size-3.5">
-                                      <AvatarImage
-                                        src={
-                                          agent.icon?.value ||
-                                          EMOJI_DATA[
-                                            (i + myAgents.length) %
-                                              EMOJI_DATA.length
-                                          ]
-                                        }
-                                      />
-                                      <AvatarFallback className="bg-transparent">
-                                        {agent.name[0]}
-                                      </AvatarFallback>
-                                    </Avatar>
-                                  </div>
-
-                                  <div className="flex items-center min-w-0 w-full">
-                                    <p className="truncate">{agent.name}</p>
-                                  </div>
-                                  <div
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      e.preventDefault();
-                                    }}
-                                  >
-                                    <AgentDropdown
-                                      agent={agent}
-                                      side="right"
-                                      align="start"
-                                    >
-                                      <SidebarMenuAction className="data-[state=open]:bg-input! data-[state=open]:opacity-100 opacity-0 group-hover/agent:opacity-100 mr-2">
-                                        <MoreHorizontal className="size-4" />
-                                      </SidebarMenuAction>
-                                    </AgentDropdown>
-                                  </div>
+                              <div className="flex gap-1 w-full min-w-0">
+                                <div
+                                  className="p-1 rounded-full ring-2 ring-border bg-background"
+                                  style={{
+                                    backgroundColor:
+                                      agent.icon?.style?.backgroundColor ||
+                                      BACKGROUND_COLORS[
+                                        i % BACKGROUND_COLORS.length
+                                      ],
+                                  }}
+                                >
+                                  <Avatar className="size-3.5">
+                                    <AvatarImage
+                                      src={
+                                        agent.icon?.value ||
+                                        EMOJI_DATA[i % EMOJI_DATA.length]
+                                      }
+                                    />
+                                    <AvatarFallback className="bg-transparent">
+                                      {agent.name[0]}
+                                    </AvatarFallback>
+                                  </Avatar>
                                 </div>
-                              </SidebarMenuButton>
-                            </SidebarMenuItem>
-                          </SidebarMenu>
-                        );
-                      })}
-                    </>
+
+                                <div className="flex items-center min-w-0 w-full">
+                                  <p className="truncate">{agent.name}</p>
+                                </div>
+                                <div
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    e.preventDefault();
+                                  }}
+                                >
+                                  <AgentDropdown
+                                    agent={agent}
+                                    side="right"
+                                    align="start"
+                                  >
+                                    <SidebarMenuAction className="data-[state=open]:bg-input! data-[state=open]:opacity-100  opacity-0 group-hover/agent:opacity-100 mr-2">
+                                      <MoreHorizontal className="size-4" />
+                                    </SidebarMenuAction>
+                                  </AgentDropdown>
+                                </div>
+                              </div>
+                            </SidebarMenuButton>
+                          </SidebarMenuItem>
+                        </SidebarMenu>
+                      );
+                    },
                   )}
                 </div>
               </div>
 
               {/* Show More/Less Button */}
-              {myAgents.length + bookmarkedAgents.length > DISPLAY_LIMIT && (
+              {agents.length > DISPLAY_LIMIT && (
                 <SidebarMenu className="group/showmore mr-0 mt-2">
                   <SidebarMenuItem className="px-2 cursor-pointer">
                     <SidebarMenuButton

--- a/src/components/layouts/app-sidebar-agents.tsx
+++ b/src/components/layouts/app-sidebar-agents.tsx
@@ -18,7 +18,7 @@ import { useMounted } from "@/hooks/use-mounted";
 import { Tooltip, TooltipContent, TooltipTrigger } from "ui/tooltip";
 
 import { useTranslations } from "next-intl";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useAgents } from "@/hooks/queries/use-agents";
 import { Avatar, AvatarFallback, AvatarImage } from "ui/avatar";
 import { AgentDropdown } from "../agent/agent-dropdown";
@@ -35,7 +35,13 @@ export function AppSidebarAgents() {
   const t = useTranslations();
   const router = useRouter();
   const [expanded, setExpanded] = useState(false);
-  const { agents, sharedAgents, isLoading } = useAgents({ limit: 50 }); // Increase limit since we're not artificially limiting display
+  const { bookmarkedAgents, myAgents, sharedAgents, isLoading } = useAgents({
+    limit: 50,
+  }); // Increase limit since we're not artificially limiting display
+
+  const agents = useMemo(() => {
+    return [...myAgents, ...bookmarkedAgents];
+  }, [bookmarkedAgents, myAgents]);
 
   const handleAgentClick = useCallback(
     (id: string) => {

--- a/src/components/layouts/app-sidebar-agents.tsx
+++ b/src/components/layouts/app-sidebar-agents.tsx
@@ -5,14 +5,20 @@ import Link from "next/link";
 import { SidebarMenuButton, SidebarMenuSkeleton } from "ui/sidebar";
 import { SidebarGroupContent, SidebarMenu, SidebarMenuItem } from "ui/sidebar";
 import { SidebarGroup } from "ui/sidebar";
-import { ArrowUpRightIcon, MoreHorizontal, PlusIcon } from "lucide-react";
+import {
+  ArrowUpRightIcon,
+  ChevronDown,
+  ChevronUp,
+  MoreHorizontal,
+  PlusIcon,
+} from "lucide-react";
 
 import { useMounted } from "@/hooks/use-mounted";
 
 import { Tooltip, TooltipContent, TooltipTrigger } from "ui/tooltip";
 
 import { useTranslations } from "next-intl";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { useAgents } from "@/hooks/queries/use-agents";
 import { Avatar, AvatarFallback, AvatarImage } from "ui/avatar";
 import { AgentDropdown } from "../agent/agent-dropdown";
@@ -23,10 +29,13 @@ import { ChatMention } from "app-types/chat";
 import { BACKGROUND_COLORS, EMOJI_DATA } from "lib/const";
 import { Separator } from "ui/separator";
 
+const DISPLAY_LIMIT = 5; // Number of agents to show when collapsed
+
 export function AppSidebarAgents() {
   const mounted = useMounted();
   const t = useTranslations();
   const router = useRouter();
+  const [expanded, setExpanded] = useState(false);
   const { agents, myAgents, bookmarkedAgents, sharedAgents, isLoading } =
     useAgents({ limit: 50 }); // Increase limit since we're not artificially limiting display
 
@@ -129,9 +138,16 @@ export function AppSidebarAgents() {
             </div>
           ) : (
             <>
-              <div className="h-[200px] w-full overflow-y-auto">
+              <div
+                className={
+                  expanded ? "max-h-[300px] w-full overflow-y-auto" : "w-full"
+                }
+              >
                 <div className="flex flex-col gap-1">
-                  {myAgents?.map((agent, i) => {
+                  {(expanded
+                    ? myAgents
+                    : myAgents.slice(0, DISPLAY_LIMIT)
+                  )?.map((agent, i) => {
                     return (
                       <SidebarMenu
                         key={agent.id}
@@ -195,7 +211,7 @@ export function AppSidebarAgents() {
                     );
                   })}
 
-                  {bookmarkedAgents.length > 0 && (
+                  {bookmarkedAgents.length > 0 && expanded && (
                     <>
                       <Separator className="my-1" />
                       {bookmarkedAgents.map((agent, i) => {
@@ -269,6 +285,31 @@ export function AppSidebarAgents() {
                   )}
                 </div>
               </div>
+
+              {/* Show More/Less Button */}
+              {myAgents.length + bookmarkedAgents.length > DISPLAY_LIMIT && (
+                <SidebarMenu className="group/showmore mr-0 mt-2">
+                  <SidebarMenuItem className="px-2 cursor-pointer">
+                    <SidebarMenuButton
+                      onClick={() => setExpanded(!expanded)}
+                      className="text-muted-foreground hover:text-foreground"
+                    >
+                      <div className="flex items-center gap-1">
+                        <p className="text-xs">
+                          {expanded
+                            ? t("Common.showLess")
+                            : t("Common.showMore")}
+                        </p>
+                        {expanded ? (
+                          <ChevronUp className="size-3.5" />
+                        ) : (
+                          <ChevronDown className="size-3.5" />
+                        )}
+                      </div>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                </SidebarMenu>
+              )}
             </>
           )}
         </SidebarMenu>

--- a/src/components/layouts/app-sidebar-agents.tsx
+++ b/src/components/layouts/app-sidebar-agents.tsx
@@ -27,6 +27,7 @@ import { appStore } from "@/app/store";
 import { useRouter } from "next/navigation";
 import { ChatMention } from "app-types/chat";
 import { BACKGROUND_COLORS, EMOJI_DATA } from "lib/const";
+import { cn } from "lib/utils";
 
 const DISPLAY_LIMIT = 5; // Number of agents to show when collapsed
 
@@ -141,13 +142,17 @@ export function AppSidebarAgents() {
               </Link>
             </div>
           ) : (
-            <>
-              <div
-                className={
-                  expanded ? "max-h-[200px] w-full overflow-y-auto" : "w-full"
-                }
-              >
-                <div className="flex flex-col gap-1">
+            <div className="flex flex-col">
+              <div className="relative">
+                {expanded && (
+                  <div className="absolute bottom-0 left-0 right-0 h-4 z-10 pointer-events-none bg-gradient-to-t from-background to-transparent" />
+                )}
+                <div
+                  className={cn(
+                    "w-full",
+                    expanded && "max-h-[400px] overflow-y-auto",
+                  )}
+                >
                   {(expanded ? agents : agents.slice(0, DISPLAY_LIMIT))?.map(
                     (agent, i) => {
                       return (
@@ -218,7 +223,7 @@ export function AppSidebarAgents() {
 
               {/* Show More/Less Button */}
               {agents.length > DISPLAY_LIMIT && (
-                <SidebarMenu className="group/showmore mr-0 mt-2">
+                <SidebarMenu className="group/showmore">
                   <SidebarMenuItem className="px-2 cursor-pointer">
                     <SidebarMenuButton
                       onClick={() => setExpanded(!expanded)}
@@ -240,7 +245,7 @@ export function AppSidebarAgents() {
                   </SidebarMenuItem>
                 </SidebarMenu>
               )}
-            </>
+            </div>
           )}
         </SidebarMenu>
       </SidebarGroupContent>

--- a/src/components/layouts/app-sidebar.tsx
+++ b/src/components/layouts/app-sidebar.tsx
@@ -90,7 +90,7 @@ export function AppSidebar({
       </SidebarHeader>
 
       <SidebarContent className="mt-2 overflow-hidden relative">
-        <div className="flex flex-col gap-2 overflow-y-auto">
+        <div className="flex flex-col overflow-y-auto">
           <AppSidebarMenus />
           <AppSidebarAgents />
           <AppSidebarThreads />

--- a/src/components/shareable-actions.tsx
+++ b/src/components/shareable-actions.tsx
@@ -6,7 +6,6 @@ import {
   Globe,
   Bookmark,
   BookmarkCheck,
-  Edit,
   Trash2,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -19,6 +18,7 @@ import {
   DropdownMenuTrigger,
 } from "ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "ui/tooltip";
+import { WriteIcon } from "ui/write-icon";
 
 export type Visibility = "private" | "public" | "readonly";
 
@@ -56,7 +56,7 @@ const VISIBILITY_CONFIG = {
   },
 } as const;
 
-interface ItemActionsProps {
+interface ShareableActionsProps {
   type: "agent" | "workflow";
   visibility?: Visibility;
   isOwner: boolean;
@@ -68,7 +68,7 @@ interface ItemActionsProps {
   renderActions?: () => React.ReactNode;
 }
 
-export function ItemActions({
+export function ShareableActions({
   type,
   visibility,
   isOwner,
@@ -78,7 +78,7 @@ export function ItemActions({
   onBookmarkToggle,
   onDelete,
   renderActions,
-}: ItemActionsProps) {
+}: ShareableActionsProps) {
   const t = useTranslations();
   const router = useRouter();
 
@@ -104,26 +104,29 @@ export function ItemActions({
             <DropdownMenu>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="size-8 text-muted-foreground hover:text-foreground"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                      }}
-                    >
-                      <VisibilityIcon className="size-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
+                  <div>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-8 data-[state=open]:bg-input text-muted-foreground hover:text-foreground"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                        }}
+                      >
+                        <VisibilityIcon className="size-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                  </div>
                 </TooltipTrigger>
                 <TooltipContent>Change visibility</TooltipContent>
               </Tooltip>
-              <DropdownMenuContent align="end">
+              <DropdownMenuContent className="max-w-sm">
                 {visibilityItems.map((visibilityItem) => (
                   <DropdownMenuItem
                     key={visibilityItem.value}
+                    className="cursor-pointer"
                     disabled={visibility === visibilityItem.value}
                     onClick={() => onVisibilityChange(visibilityItem.value)}
                   >
@@ -194,7 +197,7 @@ export function ItemActions({
                 router.push(editHref);
               }}
             >
-              <Edit className="size-4" />
+              <WriteIcon className="size-4" />
             </Button>
           </TooltipTrigger>
           <TooltipContent>{t("Common.edit")}</TooltipContent>

--- a/src/components/shareable-card.tsx
+++ b/src/components/shareable-card.tsx
@@ -12,18 +12,18 @@ import { Avatar, AvatarFallback, AvatarImage } from "ui/avatar";
 import { useTranslations } from "next-intl";
 import { format } from "date-fns";
 import { cn } from "lib/utils";
-import { ItemActions, type Visibility } from "ui/item-actions";
+import { ShareableActions, type Visibility } from "./shareable-actions";
 import { WorkflowSummary } from "app-types/workflow";
 import { AgentSummary } from "app-types/agent";
 import Link from "next/link";
 
-export interface ItemIcon {
+export interface ShareableIcon {
   value?: string;
   style?: {
     backgroundColor?: string;
   };
 }
-interface ItemCardProps {
+interface ShareableCardProps {
   type: "agent" | "workflow";
   item: AgentSummary | WorkflowSummary;
   isOwner?: boolean;
@@ -33,7 +33,7 @@ interface ItemCardProps {
   onDelete?: (itemId: string) => void;
 }
 
-export function ItemCard({
+export function ShareableCard({
   type,
   item,
   isOwner = true,
@@ -41,7 +41,7 @@ export function ItemCard({
   onBookmarkToggle,
   onVisibilityChange,
   onDelete,
-}: ItemCardProps) {
+}: ShareableCardProps) {
   const t = useTranslations();
   const isPublished = (item as WorkflowSummary).isPublished;
   const isBookmarked = (item as AgentSummary).isBookmarked;
@@ -54,7 +54,7 @@ export function ItemCard({
         )}
       >
         <CardHeader className="shrink gap-y-0">
-          <CardTitle className="flex gap-3 items-start min-w-0">
+          <CardTitle className="flex gap-3 items-stretch min-w-0">
             <div
               style={{ backgroundColor: item.icon?.style?.backgroundColor }}
               className="p-2 rounded-lg flex items-center justify-center ring ring-background border shrink-0"
@@ -65,7 +65,7 @@ export function ItemCard({
               </Avatar>
             </div>
 
-            <div className="flex flex-col min-w-0 flex-1 overflow-hidden">
+            <div className="flex flex-col justify-around min-w-0 flex-1 overflow-hidden">
               <span className="truncate font-medium">{item.name}</span>
               <div className="text-xs text-muted-foreground flex items-center gap-1 min-w-0">
                 <time className="shrink-0">
@@ -90,7 +90,7 @@ export function ItemCard({
         <CardFooter className="shrink min-h-0 overflow-visible">
           <div className="flex items-center justify-between w-full min-w-0">
             <div onClick={(e) => e.stopPropagation()}>
-              <ItemActions
+              <ShareableActions
                 type={type}
                 visibility={item.visibility}
                 isOwner={isOwner}

--- a/src/components/workflow/workflow-panel.tsx
+++ b/src/components/workflow/workflow-panel.tsx
@@ -13,7 +13,7 @@ import equal from "lib/equal";
 
 import { Avatar, AvatarFallback, AvatarImage } from "ui/avatar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "ui/tooltip";
-import { ItemActions } from "@/components/ui/item-actions";
+import { ShareableActions } from "@/components/shareable-actions";
 
 import { DBWorkflow } from "app-types/workflow";
 
@@ -229,7 +229,7 @@ export const WorkflowPanel = memo(
               </p>
             </TooltipContent>
           </Tooltip>
-          <ItemActions
+          <ShareableActions
             type="workflow"
             visibility={workflow.visibility}
             isOwner={hasEditAccess || false}


### PR DESCRIPTION
> I am the better-chatbot manager bot. This comment may be incorrect.

This PR refactors and improves the UI/UX for the #226 feature.

- Updated the UI to align with the project's design guidelines.
- Renamed and moved the `agent` and `workflow` card components from `components/ui/item-card` to `components/shareable-card`. The `ui` folder is now reserved for domain-agnostic, purely shared components. Since the previous `item-card` was only used for the `agent` and `workflow` features, it has been relocated and renamed accordingly.
- Added stream support for "generate agent with AI".
- Changed the deletion confirmation from `window.confirm` to `notify.confirm` for a better user experience.


##  Confirm Dialog Update

#### before 
<img width="1558" height="979" alt="스크린샷 2025-08-10 12 04 07" src="https://github.com/user-attachments/assets/430e582e-4440-462c-a69d-64a0d6d54ece" />


#### after
<img width="1616" height="864" alt="스크린샷 2025-08-10 12 03 55" src="https://github.com/user-attachments/assets/084c1541-fb2a-4277-b40d-91efedcfc85b" />


## Agent Delete Button Alignment Update

#### before 
<img width="1652" height="931" alt="스크린샷 2025-08-10 12 02 21" src="https://github.com/user-attachments/assets/bf0dc66b-e16d-459d-9a01-f8a1561749af" />

#### after
![dd](https://github.com/user-attachments/assets/28ebd15a-d812-42e8-9d47-9a3aadcf6bc5)


## Sidebar Agent List Show More/Show Less UI Improvement

#### before 
<img width="338" height="439" alt="스크린샷 2025-08-10 12 05 33" src="https://github.com/user-attachments/assets/9ae4b6c4-50bd-444c-a3f0-65d8936191a3" />

#### after
<img width="286" height="287" alt="스크린샷 2025-08-10 12 15 32" src="https://github.com/user-attachments/assets/7dbeaf7f-f49c-4570-8594-c797c76eacd3" />


## Visibility Button Popup Enhancement

#### before 
<img width="1654" height="918" alt="스크린샷 2025-08-10 12 01 21" src="https://github.com/user-attachments/assets/696d9b79-004c-4aab-a91c-b31d9a3c2769" />

#### after
<img width="1660" height="913" alt="스크린샷 2025-08-10 12 01 38" src="https://github.com/user-attachments/assets/09da88ce-5bb3-4466-89d3-ce9ddcd02c7d" />

