### PR TITLE
fix: model name for gpt-4.1-mini in staticModels

### DIFF
--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -25,7 +25,7 @@ const groq = createGroq({
 const staticModels = {
   openai: {
     "gpt-4.1": openai("gpt-4.1"),
-    "gpt-4.1-mini": openai("gpt-4.1-migrate"),
+    "gpt-4.1-mini": openai("gpt-4.1-mini"),
     "o4-mini": openai("o4-mini"),
     o3: openai("o3"),
     "gpt-5": openai("gpt-5"),


### PR DESCRIPTION
This pull request makes a small but important correction to the configuration of AI models. The change updates the mapping for the `gpt-4.1-mini` model to use the correct identifier.

* Updated the `gpt-4.1-mini` entry in the `staticModels.openai` object in `src/lib/ai/models.ts` to use `openai("gpt-4.1-mini")` instead of `openai("gpt-4.1-migrate")`.