### PR TITLE
feat: s3 storage and richer file support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,8 +102,25 @@ MCP_MAX_TOTAL_TIMEOUT=
 # BLOB_READ_WRITE_TOKEN=
 
 
-# -- S3 (planned driver) --
+# -- S3 --
 # FILE_STORAGE_TYPE=s3
 # FILE_STORAGE_PREFIX=uploads
 # FILE_STORAGE_S3_BUCKET=
 # FILE_STORAGE_S3_REGION=
+# Optional: Use when serving files via CDN/custom domain
+# FILE_STORAGE_S3_PUBLIC_BASE_URL=https://cdn.example.com
+# Optional: For S3-compatible endpoints (e.g., MinIO)
+# FILE_STORAGE_S3_ENDPOINT=http://localhost:9000
+# Optional: Force path-style URLs (1/true to enable)
+# FILE_STORAGE_S3_FORCE_PATH_STYLE=1
+
+
+# AWS Credentials (server only)
+# The AWS SDK automatically discovers credentials in this order:
+# 1) Environment variables below, 2) ~/.aws/credentials or AWS_PROFILE,
+# 3) IAM role attached to the runtime (EC2/ECS/EKS/Lambda).
+# You do NOT need to set these when using an IAM role.
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+# AWS_SESSION_TOKEN=
+# AWS_REGION=us-east-1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- App code lives in `src`.
+  - `src/app` (Next.js routes, API, middleware)
+  - `src/components` (UI; reusable components in PascalCase)
+  - `src/lib` (helpers: auth, db, ai, validations, etc.)
+  - `src/hooks` (React hooks: `useX`)
+- Assets in `public/`. End‑to‑end tests in `tests/`. Scripts in `scripts/`. Docker files in `docker/`.
+
+## Build, Test, and Development Commands
+- `pnpm dev` — Run the app locally (Next.js dev server).
+- `pnpm build` / `pnpm start` — Production build and run.
+- `pnpm lint` / `pnpm lint:fix` — ESLint + Biome checks and autofix.
+- `pnpm format` — Format with Biome.
+- `pnpm test` / `pnpm test:watch` — Unit tests (Vitest).
+- `pnpm test:e2e` — Playwright tests; uses `playwright.config.ts` webServer.
+- DB: `pnpm db:push`, `pnpm db:studio`, `pnpm db:migrate` (Drizzle Kit).
+- Docker: `pnpm docker-compose:up` / `:down` to run local stack.
+
+## Coding Style & Naming Conventions
+- TypeScript everywhere. Prefer `zod` for validation.
+- Formatting via Biome: 2 spaces, LF, width 80, double quotes.
+- Components: `PascalCase.tsx`; hooks/utilities: `camelCase.ts`.
+- Co-locate small module tests next to code; larger suites under `tests/`.
+- Keep modules focused; avoid circular deps; use `src/lib` for shared logic.
+
+## Testing Guidelines
+- Unit tests: Vitest, filename `*.test.ts(x)`.
+- E2E: Playwright under `tests/`, filename `*.spec.ts`.
+- Run locally: `pnpm test` and `pnpm test:e2e` (ensure app is running or let Playwright start via config).
+- Add tests for new features and bug fixes; cover happy path + one failure mode.
+
+## Commit & Pull Request Guidelines
+- Conventional Commits: `feat:`, `fix:`, `chore:`, `docs:`, etc. Example: `feat: add image generation tool`.
+- Branch names: `feat/…`, `fix/…`, `chore/…`.
+- PRs: clear description, linked issues, screenshots or terminal output when UI/CLI changes; list test coverage and manual steps.
+- Before opening PR: `pnpm check` (lint+types+tests) should pass.
+
+## Security & Configuration Tips
+- Copy `.env.example` to `.env`; never commit secrets. For local HTTP use `NO_HTTPS=1` or `pnpm build:local`.
+- If using DB/Redis locally, start services via Docker scripts or your own stack.

--- a/docs/storage/s3-setup.md
+++ b/docs/storage/s3-setup.md
@@ -1,0 +1,61 @@
+# S3 Storage Setup
+
+This app supports S3 for file uploads (dev/prod). Development can rely on presigned PUTs directly from the browser, while production should keep the bucket private and serve via CDN (CloudFront + Origin Access Control) or signed GET URLs.
+
+## Buckets
+- Pick a region (e.g., `us-east-2`)
+  - Dev/Test example: `better-chatbot-dev` (public GET on `uploads/` only if needed)
+  - Prod example: `better-chatbot-prod` (private)
+- Enable default encryption (SSE-S3) and versioning on both buckets.
+
+## CORS
+- Dev bucket: allow PUT/GET/HEAD from the origins you use locally and in staging, for example:
+  - `http://localhost:3000`, `http://127.0.0.1:3000`
+  - `https://staging.your-domain.com`, `http://staging.your-domain.com`
+- Prod bucket: allow GET/HEAD only from your production domain (e.g., `https://app.your-domain.com`). Avoid enabling browser PUT in production.
+
+## Dev public-read policy (prefix-only)
+Grant public GET for the `uploads/` prefix on the dev bucket only if you need unauthenticated downloads:
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowPublicReadForUploadsPrefix",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::better-chatbot-dev/uploads/*"
+    }
+  ]
+}
+```
+
+## IAM (app runtime)
+Least privilege for app role/user:
+- Actions: `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`, `s3:HeadObject`
+- Resources: `arn:aws:s3:::<bucket-name>/uploads/*`
+
+## Env configuration
+- Dev/local:
+  - `FILE_STORAGE_TYPE=s3`
+  - `FILE_STORAGE_PREFIX=uploads`
+  - `FILE_STORAGE_S3_BUCKET=better-chatbot-dev`
+  - `FILE_STORAGE_S3_REGION=us-east-2` (or set `AWS_REGION`)
+  - Use AWS SSO/profile or `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`
+- Prod:
+  - `FILE_STORAGE_S3_BUCKET=better-chatbot-prod`
+  - Prefer CloudFront; set `FILE_STORAGE_S3_PUBLIC_BASE_URL=https://<cdn-domain>`
+
+## Verify locally
+- Ensure `aws sso login --profile <your_profile>` (or credentials are already available).
+- Test presign script:
+```
+AWS_PROFILE=<your_profile> \
+FILE_STORAGE_TYPE=s3 \
+FILE_STORAGE_S3_BUCKET=better-chatbot-dev \
+FILE_STORAGE_S3_REGION=us-east-2 \
+pnpm tsx scripts/verify-s3-upload-url.ts
+```
+- You should get `{ directUploadSupported: true, url, key, method: PUT }`.
+- Upload with curl (optional): `curl -X PUT -H "Content-Type: image/png" --data-binary @file.png "<url>"`.

--- a/messages/en.json
+++ b/messages/en.json
@@ -194,7 +194,7 @@
   "Chat": {
     "Error": "Chat Error",
     "thisMessageWasNotSavedPleaseTryTheChatAgain": "This message was not saved. Please try the chat again.",
-    "uploadImage": "Upload Image",
+    "uploadImage": "Upload File",
     "generateImage": "Generate Image",
     "imageUploadedSuccessfully": "Image uploaded successfully",
     "pleaseUploadImageFile": "Please upload an image file",

--- a/messages/es.json
+++ b/messages/es.json
@@ -74,7 +74,7 @@
   "Chat": {
     "Error": "Error de Chat",
     "thisMessageWasNotSavedPleaseTryTheChatAgain": "Este mensaje no se guardó. Por favor, intenta el chat nuevamente.",
-    "uploadImage": "Subir Imagen",
+    "uploadImage": "Subir archivo",
     "generateImage": "Generar Imagen",
     "imageUploadedSuccessfully": "Imagen subida exitosamente",
     "pleaseUploadImageFile": "Por favor sube un archivo de imagen",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -74,7 +74,7 @@
   "Chat": {
     "Error": "Erreur de Chat",
     "thisMessageWasNotSavedPleaseTryTheChatAgain": "Ce message n'a pas été enregistré. Veuillez réessayer le chat.",
-    "uploadImage": "Télécharger une Image",
+    "uploadImage": "Téléverser un fichier",
     "generateImage": "Générer une Image",
     "imageUploadedSuccessfully": "Image téléchargée avec succès",
     "pleaseUploadImageFile": "Veuillez télécharger un fichier image",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -74,7 +74,7 @@
   "Chat": {
     "Error": "チャットエラー",
     "thisMessageWasNotSavedPleaseTryTheChatAgain": "このメッセージは保存されませんでした。もう一度チャットをお試しください。",
-    "uploadImage": "画像をアップロード",
+    "uploadImage": "ファイルをアップロード",
     "generateImage": "画像を生成",
     "imageUploadedSuccessfully": "画像が正常にアップロードされました",
     "pleaseUploadImageFile": "画像ファイルをアップロードしてください",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -75,7 +75,7 @@
   "Chat": {
     "Error": "채팅 오류",
     "thisMessageWasNotSavedPleaseTryTheChatAgain": "이 메시지는 저장되지 않았습니다. 다시 시도해주세요.",
-    "uploadImage": "이미지 업로드",
+    "uploadImage": "파일 업로드",
     "generateImage": "이미지 만들기",
     "imageUploadedSuccessfully": "이미지가 성공적으로 업로드되었습니다",
     "pleaseUploadImageFile": "이미지 파일을 업로드해주세요",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -75,7 +75,7 @@
   "Chat": {
     "Error": "聊天错误",
     "thisMessageWasNotSavedPleaseTryTheChatAgain": "此消息未保存。请重试聊天。",
-    "uploadImage": "上传图片",
+    "uploadImage": "上传文件",
     "generateImage": "生成图片",
     "imageUploadedSuccessfully": "图片上传成功",
     "pleaseUploadImageFile": "请上传图片文件",

--- a/src/app/api/storage/actions.test.ts
+++ b/src/app/api/storage/actions.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const importActions = async () => await import("./actions");
+
+describe("checkStorageAction", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.FILE_STORAGE_TYPE;
+    delete process.env.BLOB_READ_WRITE_TOKEN;
+    delete process.env.FILE_STORAGE_S3_BUCKET;
+    delete process.env.FILE_STORAGE_S3_REGION;
+    delete process.env.AWS_REGION;
+  });
+
+  it("invalid when vercel-blob missing token", async () => {
+    process.env.FILE_STORAGE_TYPE = "vercel-blob";
+    const { checkStorageAction } = await importActions();
+    const res = await checkStorageAction();
+    expect(res.isValid).toBe(false);
+    expect(res.error).toMatch(/BLOB_READ_WRITE_TOKEN/);
+  });
+
+  it("s3 missing config", async () => {
+    process.env.FILE_STORAGE_TYPE = "s3";
+    const { checkStorageAction } = await importActions();
+    const res = await checkStorageAction();
+    expect(res.isValid).toBe(false);
+    expect(res.error).toMatch(/Missing S3 configuration/);
+  });
+
+  it("s3 valid with required envs", async () => {
+    process.env.FILE_STORAGE_TYPE = "s3";
+    process.env.FILE_STORAGE_S3_BUCKET = "bucket";
+    process.env.FILE_STORAGE_S3_REGION = "us-east-1";
+    const { checkStorageAction } = await importActions();
+    const res = await checkStorageAction();
+    expect(res.isValid).toBe(true);
+  });
+});

--- a/src/app/api/storage/ingest/route.ts
+++ b/src/app/api/storage/ingest/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { serverFileStorage } from "lib/file-storage";
+import { parseCsvPreview, formatCsvPreviewText } from "lib/file-ingest/csv";
+import { storageKeyFromUrl } from "lib/file-storage/storage-utils";
+
+type Body = {
+  key?: string; // storage key (preferred)
+  url?: string; // will be converted to key if possible
+  type?: "csv" | "auto";
+  maxRows?: number;
+  maxCols?: number;
+};
+
+export async function POST(req: Request) {
+  let body: Body;
+  try {
+    body = (await req.json()) as Body;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const key = body.key || (body.url ? storageKeyFromUrl(body.url) : undefined);
+  if (!key) {
+    return NextResponse.json(
+      { error: "Missing 'key' or 'url'" },
+      { status: 400 },
+    );
+  }
+
+  // Infer type from extension when auto
+  const type = body.type || "auto";
+  const isCsv =
+    type === "csv" ||
+    /\.(csv)$/i.test(key) ||
+    /(^|[?&])contentType=text\/csv(&|$)/i.test(body.url || "");
+
+  if (!isCsv) {
+    return NextResponse.json(
+      {
+        error: "Unsupported file type for ingest",
+        solution:
+          "Currently supported: CSV. Convert your spreadsheet to CSV or paste sample rows.",
+      },
+      { status: 400 },
+    );
+  }
+
+  const buf = await serverFileStorage.download(key);
+  const preview = parseCsvPreview(buf, {
+    maxRows: Math.min(200, Math.max(1, body.maxRows ?? 50)),
+    maxCols: Math.min(40, Math.max(1, body.maxCols ?? 12)),
+  });
+
+  const text = formatCsvPreviewText(key, preview);
+
+  return NextResponse.json({ ok: true, type: "csv", key, preview, text });
+}

--- a/src/app/api/storage/upload-url/route.ts
+++ b/src/app/api/storage/upload-url/route.ts
@@ -107,9 +107,13 @@ async function handleGenericUpload(request: GenericUploadRequest) {
     return NextResponse.json(createFallbackResponse());
   }
 
+  // Provide a public source URL for clients to reference after successful PUT
+  const sourceUrl = await serverFileStorage.getSourceUrl(uploadUrl.key);
+
   return NextResponse.json({
     directUploadSupported: true,
     ...uploadUrl,
+    sourceUrl,
   });
 }
 

--- a/src/components/chat-bot.tsx
+++ b/src/components/chat-bot.tsx
@@ -21,13 +21,17 @@ import {
 
 import { safe } from "ts-safe";
 import { mutate } from "swr";
-import { ChatApiSchemaRequestBody, ChatModel } from "app-types/chat";
+import {
+  ChatApiSchemaRequestBody,
+  ChatAttachment,
+  ChatModel,
+} from "app-types/chat";
 import { useToRef } from "@/hooks/use-latest";
 import { isShortcutEvent, Shortcuts } from "lib/keyboard-shortcuts";
 import { Button } from "ui/button";
 import { deleteThreadAction } from "@/app/api/chat/actions";
 import { useRouter } from "next/navigation";
-import { ArrowDown, Loader } from "lucide-react";
+import { ArrowDown, Loader, FilePlus } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -43,6 +47,8 @@ import dynamic from "next/dynamic";
 import { useMounted } from "@/hooks/use-mounted";
 import { getStorageManager } from "lib/browser-stroage";
 import { AnimatePresence, motion } from "framer-motion";
+import { useThreadFileUploader } from "@/hooks/use-thread-file-uploader";
+import { useFileDragOverlay } from "@/hooks/use-file-drag-overlay";
 
 type Props = {
   threadId: string;
@@ -67,6 +73,17 @@ firstTimeStorage.set(false);
 export default function ChatBot({ threadId, initialMessages }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isAtBottom, setIsAtBottom] = useState(true);
+  const { uploadFiles } = useThreadFileUploader(threadId);
+  const handleFileDrop = useCallback(
+    async (files: File[]) => {
+      if (!files.length) return;
+      await uploadFiles(files);
+    },
+    [uploadFiles],
+  );
+  const { isDragging } = useFileDragOverlay({
+    onDropFiles: handleFileDrop,
+  });
 
   const [
     appStoreMutate,
@@ -146,6 +163,36 @@ export default function ChatBot({ threadId, initialMessages }: Props) {
           window.history.replaceState({}, "", `/chat/${threadId}`);
         }
         const lastMessage = messages.at(-1)!;
+        // Filter out UI-only parts (e.g., source-url) so the model doesn't receive unknown parts
+        const attachments: ChatAttachment[] = lastMessage.parts.reduce(
+          (acc: ChatAttachment[], part: any) => {
+            if (part?.type === "file") {
+              acc.push({
+                type: "file",
+                url: part.url,
+                mediaType: part.mediaType,
+                filename: part.filename,
+              });
+            } else if (part?.type === "source-url") {
+              acc.push({
+                type: "source-url",
+                url: part.url,
+                mediaType: part.mediaType,
+                filename: part.title,
+              });
+            }
+            return acc;
+          },
+          [],
+        );
+
+        const sanitizedLastMessage = {
+          ...lastMessage,
+          parts: lastMessage.parts.filter((p: any) => p?.type !== "source-url"),
+        } as typeof lastMessage;
+        const hasFilePart = lastMessage.parts?.some(
+          (p) => (p as any)?.type === "file",
+        );
 
         const requestBody: ChatApiSchemaRequestBody = {
           ...body,
@@ -153,17 +200,19 @@ export default function ChatBot({ threadId, initialMessages }: Props) {
           chatModel:
             (body as { model: ChatModel })?.model ?? latestRef.current.model,
           toolChoice: latestRef.current.toolChoice,
-          allowedAppDefaultToolkit: latestRef.current.mentions?.length
-            ? []
-            : latestRef.current.allowedAppDefaultToolkit,
+          allowedAppDefaultToolkit:
+            latestRef.current.mentions?.length || hasFilePart
+              ? []
+              : latestRef.current.allowedAppDefaultToolkit,
           allowedMcpServers: latestRef.current.mentions?.length
             ? {}
             : latestRef.current.allowedMcpServers,
           mentions: latestRef.current.mentions,
-          message: lastMessage,
+          message: sanitizedLastMessage,
           imageTool: {
             model: latestRef.current.threadImageToolModel[threadId],
           },
+          attachments,
         };
         return { body: requestBody };
       },
@@ -363,6 +412,18 @@ export default function ChatBot({ threadId, initialMessages }: Props) {
           "flex flex-col min-w-0 relative h-full z-40",
         )}
       >
+        {isDragging && (
+          <div className="absolute inset-0 z-40 bg-background/70 backdrop-blur-sm flex items-center justify-center pointer-events-none">
+            <div className="rounded-2xl px-6 py-5 bg-background/80 shadow-xl border border-border flex items-center gap-3">
+              <div className="rounded-full bg-primary/10 p-2 text-primary">
+                <FilePlus className="size-6" />
+              </div>
+              <span className="text-sm text-muted-foreground">
+                Drop files to upload
+              </span>
+            </div>
+          </div>
+        )}
         {emptyMessage ? (
           <ChatGreeting />
         ) : (

--- a/src/components/message.tsx
+++ b/src/components/message.tsx
@@ -12,6 +12,7 @@ import {
   ToolMessagePart,
   ReasoningPart,
   FileMessagePart,
+  SourceUrlMessagePart,
 } from "./message-parts";
 import { ChevronDown, ChevronUp, TriangleAlertIcon } from "lucide-react";
 import { Button } from "ui/button";
@@ -48,10 +49,19 @@ const PurePreviewMessage = ({
   sendMessage,
 }: Props) => {
   const isUserMessage = useMemo(() => message.role === "user", [message.role]);
+  const partsForDisplay = useMemo(
+    () =>
+      message.parts.filter(
+        (part) => !(part.type === "text" && (part as any).ingestionPreview),
+      ),
+    [message.parts],
+  );
+
   if (message.role == "system") {
     return null; // system message is not shown
   }
-  if (!message.parts.length) return null;
+  if (!partsForDisplay.length) return null;
+
   return (
     <div className="w-full mx-auto max-w-3xl px-6 group/message">
       <div
@@ -61,9 +71,9 @@ const PurePreviewMessage = ({
         )}
       >
         <div className="flex flex-col gap-4 w-full">
-          {message.parts?.map((part, index) => {
+          {partsForDisplay.map((part, index) => {
             const key = `message-${messageIndex}-part-${part.type}-${index}`;
-            const isLastPart = index === message.parts.length - 1;
+            const isLastPart = index === partsForDisplay.length - 1;
 
             if (part.type === "reasoning") {
               return (
@@ -143,6 +153,14 @@ const PurePreviewMessage = ({
                 <FileMessagePart
                   key={key}
                   part={part}
+                  isUserMessage={isUserMessage}
+                />
+              );
+            } else if ((part as any).type === "source-url") {
+              return (
+                <SourceUrlMessagePart
+                  key={key}
+                  part={part as any}
                   isUserMessage={isUserMessage}
                 />
               );

--- a/src/hooks/queries/use-chat-models.ts
+++ b/src/hooks/queries/use-chat-models.ts
@@ -11,6 +11,7 @@ export const useChatModels = (options?: SWRConfiguration) => {
         name: string;
         isToolCallUnsupported: boolean;
         isImageInputUnsupported: boolean;
+        supportedFileMimeTypes: string[];
       }[];
     }[]
   >("/api/chat/models", fetcher, {

--- a/src/hooks/use-file-drag-overlay.test.ts
+++ b/src/hooks/use-file-drag-overlay.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { isFileDragEvent } from "./use-file-drag-overlay";
+
+const createDragEvent = (dataTransfer: Partial<DataTransfer> | null) =>
+  ({
+    dataTransfer: dataTransfer ?? null,
+  }) as unknown as DragEvent;
+
+describe("use-file-drag-overlay helpers", () => {
+  it("returns false when dataTransfer is missing", () => {
+    expect(isFileDragEvent(createDragEvent(null))).toBe(false);
+  });
+
+  it("detects file drag via items", () => {
+    const event = createDragEvent({
+      items: [
+        { kind: "string" },
+        { kind: "file" },
+      ] as unknown as DataTransferItemList,
+    });
+
+    expect(isFileDragEvent(event)).toBe(true);
+  });
+
+  it("returns false when no items are files", () => {
+    const event = createDragEvent({
+      items: [{ kind: "string" }] as unknown as DataTransferItemList,
+    });
+
+    expect(isFileDragEvent(event)).toBe(false);
+  });
+
+  it("uses types fallback when items are unavailable", () => {
+    const event = createDragEvent({
+      types: ["Files", "text/plain"],
+    });
+
+    expect(isFileDragEvent(event)).toBe(true);
+  });
+
+  it("returns false for non-file types", () => {
+    const event = createDragEvent({
+      types: ["text/plain"],
+    });
+
+    expect(isFileDragEvent(event)).toBe(false);
+  });
+});

--- a/src/hooks/use-file-drag-overlay.ts
+++ b/src/hooks/use-file-drag-overlay.ts
@@ -1,0 +1,106 @@
+import { useEffect, useRef, useState } from "react";
+import type { DragEvent as ReactDragEvent } from "react";
+
+type DragEventLike = DragEvent | ReactDragEvent;
+
+const isFileDragDefault = (event: DragEventLike) => {
+  const dataTransfer = event.dataTransfer ?? null;
+  if (!dataTransfer) return false;
+  if (dataTransfer.items && dataTransfer.items.length) {
+    for (let i = 0; i < dataTransfer.items.length; i += 1) {
+      if (dataTransfer.items[i]?.kind === "file") {
+        return true;
+      }
+    }
+    return false;
+  }
+  const types = Array.from(dataTransfer.types ?? []);
+  return types.includes("Files");
+};
+
+interface UseFileDragOverlayOptions {
+  onDropFiles?: (files: File[]) => void | Promise<void>;
+  isFileDrag?: (event: DragEventLike) => boolean;
+}
+
+export const useFileDragOverlay = ({
+  onDropFiles,
+  isFileDrag = isFileDragDefault,
+}: UseFileDragOverlayOptions = {}) => {
+  const [isDragging, setIsDragging] = useState(false);
+  const dragCounter = useRef(0);
+  const dropHandlerRef = useRef(onDropFiles);
+  const isFileDragRef = useRef(isFileDrag);
+
+  useEffect(() => {
+    dropHandlerRef.current = onDropFiles;
+  }, [onDropFiles]);
+
+  useEffect(() => {
+    isFileDragRef.current = isFileDrag;
+  }, [isFileDrag]);
+
+  useEffect(() => {
+    const handleDragEnter = (event: DragEvent) => {
+      if (!isFileDragRef.current(event)) return;
+      event.preventDefault();
+      dragCounter.current += 1;
+      setIsDragging(true);
+    };
+
+    const handleDragOver = (event: DragEvent) => {
+      if (!isFileDragRef.current(event)) return;
+      event.preventDefault();
+      try {
+        if (event.dataTransfer) {
+          event.dataTransfer.dropEffect = "copy";
+        }
+      } catch {
+        // no-op — some browsers throw when setting dropEffect
+      }
+    };
+
+    const handleDragLeave = (event: DragEvent) => {
+      if (!isFileDragRef.current(event)) return;
+      event.preventDefault();
+      dragCounter.current = Math.max(0, dragCounter.current - 1);
+      if (dragCounter.current === 0) {
+        setIsDragging(false);
+      }
+    };
+
+    const handleDrop = async (event: DragEvent) => {
+      if (!isFileDragRef.current(event)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      dragCounter.current = 0;
+      setIsDragging(false);
+
+      if (!dropHandlerRef.current) return;
+      const files = Array.from(event.dataTransfer?.files ?? []);
+      if (files.length === 0) return;
+
+      try {
+        await dropHandlerRef.current(files);
+      } catch {
+        // Allow caller to surface errors separately
+      }
+    };
+
+    window.addEventListener("dragenter", handleDragEnter);
+    window.addEventListener("dragover", handleDragOver);
+    window.addEventListener("dragleave", handleDragLeave);
+    window.addEventListener("drop", handleDrop);
+
+    return () => {
+      window.removeEventListener("dragenter", handleDragEnter);
+      window.removeEventListener("dragover", handleDragOver);
+      window.removeEventListener("dragleave", handleDragLeave);
+      window.removeEventListener("drop", handleDrop);
+    };
+  }, []);
+
+  return { isDragging };
+};
+
+export const isFileDragEvent = isFileDragDefault;

--- a/src/hooks/use-presigned-upload.ts
+++ b/src/hooks/use-presigned-upload.ts
@@ -151,7 +151,8 @@ export function useFileUpload() {
 
           return {
             pathname: uploadUrlData.key,
-            url: uploadUrlData.url,
+            // Use server-provided public source URL (not the presigned PUT URL)
+            url: uploadUrlData.sourceUrl ?? uploadUrlData.url,
             contentType,
             size: file.size,
           };

--- a/src/hooks/use-thread-file-uploader.ts
+++ b/src/hooks/use-thread-file-uploader.ts
@@ -1,0 +1,95 @@
+"use client";
+
+import { useCallback } from "react";
+import { appStore, UploadedFile } from "@/app/store";
+import { useFileUpload } from "@/hooks/use-presigned-upload";
+import { generateUUID } from "@/lib/utils";
+import { toast } from "sonner";
+
+export function useThreadFileUploader(threadId?: string) {
+  const appStoreMutate = appStore((s) => s.mutate);
+  const { upload } = useFileUpload();
+
+  const uploadFiles = useCallback(
+    async (files: File[]) => {
+      if (!threadId || files.length === 0) return;
+      const MAX_SIZE_BYTES = 50 * 1024 * 1024; // 50MB per file
+
+      for (const file of files) {
+        if (file.size > MAX_SIZE_BYTES) {
+          toast.error(`${file.name}: file too large (>50MB)`);
+          continue;
+        }
+
+        const previewUrl = file.type?.startsWith("image/")
+          ? URL.createObjectURL(file)
+          : undefined;
+        const fileId = generateUUID();
+        const abortController = new AbortController();
+
+        const uploadingFile: UploadedFile = {
+          id: fileId,
+          url: "",
+          name: file.name,
+          mimeType: file.type || "application/octet-stream",
+          size: file.size,
+          isUploading: true,
+          progress: 0,
+          previewUrl,
+          abortController,
+        };
+
+        appStoreMutate((prev) => ({
+          threadFiles: {
+            ...prev.threadFiles,
+            [threadId]: [...(prev.threadFiles[threadId] ?? []), uploadingFile],
+          },
+        }));
+
+        try {
+          const uploaded = await upload(file);
+          if (uploaded) {
+            appStoreMutate((prev) => ({
+              threadFiles: {
+                ...prev.threadFiles,
+                [threadId]: (prev.threadFiles[threadId] ?? []).map((f) =>
+                  f.id === fileId
+                    ? {
+                        ...f,
+                        url: uploaded.url,
+                        isUploading: false,
+                        progress: 100,
+                      }
+                    : f,
+                ),
+              },
+            }));
+          } else {
+            appStoreMutate((prev) => ({
+              threadFiles: {
+                ...prev.threadFiles,
+                [threadId]: (prev.threadFiles[threadId] ?? []).filter(
+                  (f) => f.id !== fileId,
+                ),
+              },
+            }));
+          }
+        } catch (_err) {
+          appStoreMutate((prev) => ({
+            threadFiles: {
+              ...prev.threadFiles,
+              [threadId]: (prev.threadFiles[threadId] ?? []).filter(
+                (f) => f.id !== fileId,
+              ),
+            },
+          }));
+        } finally {
+          if (previewUrl) URL.revokeObjectURL(previewUrl);
+        }
+      }
+    },
+    [threadId, appStoreMutate, upload],
+  );
+
+  return { uploadFiles };
+}

--- a/src/lib/ai/file-support.test.ts
+++ b/src/lib/ai/file-support.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_FILE_PART_MIME_TYPES,
+  isFilePartSupported,
+} from "./file-support";
+
+describe("file-support", () => {
+  it("returns false when mime is missing", () => {
+    expect(isFilePartSupported(undefined)).toBe(false);
+  });
+
+  it("returns true for default supported image types", () => {
+    expect(isFilePartSupported("image/jpeg")).toBe(true);
+    expect(isFilePartSupported("image/png")).toBe(true);
+    expect(isFilePartSupported("image/webp")).toBe(true);
+    expect(isFilePartSupported("image/gif")).toBe(true);
+  });
+
+  it("returns true for default supported document types", () => {
+    expect(isFilePartSupported("application/pdf")).toBe(true);
+  });
+
+  it("returns false for unsupported mime types by default", () => {
+    expect(isFilePartSupported("text/plain")).toBe(false);
+    expect(isFilePartSupported("application/vnd.ms-excel")).toBe(false);
+  });
+
+  it("respects an explicitly provided mime whitelist", () => {
+    const whitelist = ["application/pdf"];
+    expect(isFilePartSupported("application/pdf", whitelist)).toBe(true);
+    expect(isFilePartSupported("image/png", whitelist)).toBe(false);
+  });
+
+  it("treats an empty whitelist as no support", () => {
+    expect(isFilePartSupported("image/png", [])).toBe(false);
+  });
+
+  it("exposes the default mime types constant", () => {
+    expect(DEFAULT_FILE_PART_MIME_TYPES).toContain("application/pdf");
+    expect(DEFAULT_FILE_PART_MIME_TYPES).toContain("image/jpeg");
+  });
+});

--- a/src/lib/ai/file-support.ts
+++ b/src/lib/ai/file-support.ts
@@ -1,0 +1,47 @@
+export const DEFAULT_FILE_PART_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+  // Enable PDF when supported by the chosen model/provider
+  "application/pdf",
+] as const;
+
+export const OPENAI_FILE_MIME_TYPES = [
+  ...DEFAULT_FILE_PART_MIME_TYPES,
+] as const;
+
+export const GEMINI_FILE_MIME_TYPES = [
+  ...DEFAULT_FILE_PART_MIME_TYPES,
+] as const;
+
+export const ANTHROPIC_FILE_MIME_TYPES = [
+  ...DEFAULT_FILE_PART_MIME_TYPES,
+] as const;
+
+export const XAI_FILE_MIME_TYPES = [...DEFAULT_FILE_PART_MIME_TYPES] as const;
+
+const DEFAULT_FILE_PART_MIME_SET = new Set<string>(
+  DEFAULT_FILE_PART_MIME_TYPES,
+);
+
+export const INGEST_SUPPORTED_MIME = new Set<string>([
+  "text/csv",
+  "application/csv",
+  // Future: xlsx when server-side parser is added
+  // "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+]);
+
+export const isFilePartSupported = (
+  mime?: string,
+  supportedMimeTypes?: readonly string[],
+) => {
+  if (!mime) return false;
+  if (supportedMimeTypes !== undefined) {
+    return supportedMimeTypes.includes(mime);
+  }
+  return DEFAULT_FILE_PART_MIME_SET.has(mime);
+};
+
+export const isIngestSupported = (mime?: string) =>
+  !!mime && INGEST_SUPPORTED_MIME.has(mime);

--- a/src/lib/ai/image/generate-image.ts
+++ b/src/lib/ai/image/generate-image.ts
@@ -6,6 +6,7 @@ import {
 } from "@google/genai";
 import { safe, watchError } from "ts-safe";
 import { getBase64Data } from "lib/file-storage/storage-utils";
+import { serverFileStorage } from "lib/file-storage";
 import { openai } from "@ai-sdk/openai";
 import { xai } from "@ai-sdk/xai";
 
@@ -127,13 +128,46 @@ export const generateImageWithNanoBanana = async (
 async function convertToGeminiMessage(
   message: ModelMessage,
 ): Promise<GeminiMessage> {
+  const getBase64DataSmart = async (input: {
+    data: string | Uint8Array | ArrayBuffer | Buffer | URL;
+    mimeType: string;
+  }): Promise<{ data: string; mimeType: string }> => {
+    if (
+      typeof input.data === "string" &&
+      (input.data.startsWith("http://") || input.data.startsWith("https://"))
+    ) {
+      // Try fetching directly (public URLs)
+      try {
+        const resp = await fetch(input.data);
+        if (resp.ok) {
+          const buf = Buffer.from(await resp.arrayBuffer());
+          return { data: buf.toString("base64"), mimeType: input.mimeType };
+        }
+      } catch {
+        // fall through to storage fallback
+      }
+
+      // Fallback: derive key and download via storage backend (works for private buckets)
+      try {
+        const u = new URL(input.data as string);
+        const key = decodeURIComponent(u.pathname.replace(/^\//, ""));
+        const buf = await serverFileStorage.download(key);
+        return { data: buf.toString("base64"), mimeType: input.mimeType };
+      } catch {
+        // Ignore and fall back to generic helper below
+      }
+    }
+
+    // Default fallback: use generic helper (handles base64, buffers, blobs, etc.)
+    return getBase64Data(input);
+  };
   const parts = isString(message.content)
     ? ([{ text: message.content }] as GeminiPart[])
     : await Promise.all(
         message.content.map(async (content) => {
           if (content.type == "file") {
             const part = content as FilePart;
-            const data = await getBase64Data({
+            const data = await getBase64DataSmart({
               data: part.data,
               mimeType: part.mediaType!,
             });
@@ -149,7 +183,7 @@ async function convertToGeminiMessage(
           }
           if (content.type == "image") {
             const part = content as ImagePart;
-            const data = await getBase64Data({
+            const data = await getBase64DataSmart({
               data: part.image,
               mimeType: part.mediaType!,
             });

--- a/src/lib/ai/ingest/csv-ingest.test.ts
+++ b/src/lib/ai/ingest/csv-ingest.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildCsvIngestionPreviewParts } from "./csv-ingest";
+import type { ChatAttachment } from "app-types/chat";
+
+const attachmentFactory = (
+  overrides: Partial<ChatAttachment> = {},
+): ChatAttachment => ({
+  type: "source-url",
+  url: "https://example.com/uploads/data.csv",
+  mediaType: "text/csv",
+  filename: "data.csv",
+  ...overrides,
+});
+
+describe("buildCsvIngestionPreviewParts", () => {
+  it("returns preview text for csv attachments", async () => {
+    const attachments = [attachmentFactory()];
+    const download = vi.fn(async () =>
+      Buffer.from("col1,col2\n1,2\n3,4\n", "utf8"),
+    );
+
+    const parts = await buildCsvIngestionPreviewParts(attachments, download);
+
+    expect(parts).toHaveLength(1);
+    expect(parts[0].type).toBe("text");
+    expect(parts[0].ingestionPreview).toBe(true);
+    expect(parts[0].text).toContain("rows: 3");
+    expect(parts[0].text).toContain("| col1 | col2 |");
+  });
+
+  it("skips attachments that are not csv-like", async () => {
+    const attachments = [
+      attachmentFactory({
+        mediaType: "application/json",
+        filename: "data.json",
+      }),
+    ];
+    const download = vi.fn();
+
+    const parts = await buildCsvIngestionPreviewParts(attachments, download);
+
+    expect(parts).toHaveLength(0);
+    expect(download).not.toHaveBeenCalled();
+  });
+
+  it("ignores attachments with invalid URLs", async () => {
+    const attachments = [attachmentFactory({ url: "not-a-url" })];
+    const download = vi.fn();
+
+    const parts = await buildCsvIngestionPreviewParts(attachments, download);
+
+    expect(parts).toHaveLength(0);
+    expect(download).not.toHaveBeenCalled();
+  });
+
+  it("continues when download fails", async () => {
+    const attachments = [attachmentFactory()];
+    const download = vi.fn(async () => {
+      throw new Error("network");
+    });
+
+    const parts = await buildCsvIngestionPreviewParts(attachments, download);
+
+    expect(parts).toHaveLength(0);
+    expect(download).toHaveBeenCalled();
+  });
+});

--- a/src/lib/ai/ingest/csv-ingest.ts
+++ b/src/lib/ai/ingest/csv-ingest.ts
@@ -1,0 +1,60 @@
+import { Buffer } from "node:buffer";
+import { ChatAttachment } from "app-types/chat";
+import { isIngestSupported } from "@/lib/ai/file-support";
+import { storageKeyFromUrl } from "@/lib/file-storage/storage-utils";
+import { formatCsvPreviewText, parseCsvPreview } from "@/lib/file-ingest/csv";
+
+type CsvPreviewPart = {
+  type: "text";
+  text: string;
+  ingestionPreview: true;
+};
+
+export type DownloadFile = (key: string) => Promise<Buffer>;
+
+const isCsvLikeAttachment = (attachment: ChatAttachment, key: string) => {
+  const mediaType = attachment.mediaType || "";
+  if (isIngestSupported(mediaType)) return true;
+  const name = (attachment.filename || key || "").toLowerCase();
+  if (/\.(csv)$/.test(name)) return true;
+  if (
+    /(^|[?&])contentType=text\/csv(&|$)/i.test(attachment.url || "") ||
+    /(^|[?&])content-type=text\/csv(&|$)/i.test(attachment.url || "")
+  ) {
+    return true;
+  }
+  return false;
+};
+
+export const buildCsvIngestionPreviewParts = async (
+  attachments: ChatAttachment[],
+  download: DownloadFile,
+): Promise<CsvPreviewPart[]> => {
+  if (!attachments?.length) return [];
+  const results = await Promise.all(
+    attachments.map(async (attachment) => {
+      if (attachment.type !== "source-url") return null;
+      const key = storageKeyFromUrl(attachment.url);
+      if (!key) return null;
+      if (!isCsvLikeAttachment(attachment, key)) return null;
+
+      try {
+        const buffer = await download(key);
+        const preview = parseCsvPreview(buffer, {
+          maxRows: 50,
+          maxCols: 12,
+        });
+        const text = formatCsvPreviewText(attachment.filename || key, preview);
+        return {
+          type: "text",
+          text,
+          ingestionPreview: true as const,
+        };
+      } catch (_error) {
+        return null;
+      }
+    }),
+  );
+
+  return results.filter(Boolean) as CsvPreviewPart[];
+};

--- a/src/lib/ai/models.test.ts
+++ b/src/lib/ai/models.test.ts
@@ -1,0 +1,48 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  OPENAI_FILE_MIME_TYPES,
+  ANTHROPIC_FILE_MIME_TYPES,
+} from "./file-support";
+
+vi.mock("server-only", () => ({}));
+
+let modelsModule: typeof import("./models");
+
+beforeAll(async () => {
+  modelsModule = await import("./models");
+});
+
+describe("customModelProvider file support metadata", () => {
+  it("includes default file support for OpenAI gpt-4.1", () => {
+    const { customModelProvider, getFilePartSupportedMimeTypes } = modelsModule;
+    const model = customModelProvider.getModel({
+      provider: "openai",
+      model: "gpt-4.1",
+    });
+    expect(getFilePartSupportedMimeTypes(model)).toEqual(
+      Array.from(OPENAI_FILE_MIME_TYPES),
+    );
+
+    const openaiProvider = customModelProvider.modelsInfo.find(
+      (item) => item.provider === "openai",
+    );
+    const metadata = openaiProvider?.models.find(
+      (item) => item.name === "gpt-4.1",
+    );
+
+    expect(metadata?.supportedFileMimeTypes).toEqual(
+      Array.from(OPENAI_FILE_MIME_TYPES),
+    );
+  });
+
+  it("adds rich support for anthropic sonnet-4.5", () => {
+    const { customModelProvider, getFilePartSupportedMimeTypes } = modelsModule;
+    const model = customModelProvider.getModel({
+      provider: "anthropic",
+      model: "sonnet-4.5",
+    });
+    expect(getFilePartSupportedMimeTypes(model)).toEqual(
+      Array.from(ANTHROPIC_FILE_MIME_TYPES),
+    );
+  });
+});

--- a/src/lib/ai/tools/code/python-run-tool.ts
+++ b/src/lib/ai/tools/code/python-run-tool.ts
@@ -7,7 +7,7 @@ export const pythonExecutionSchema: JSONSchema7 = {
   properties: {
     code: {
       type: "string",
-      description: `Execute Python code directly in the user's browser using Pyodide. Code runs client-side without server dependency.\n\nUse print() for output. Module imports are supported. The last expression's value will be returned if possible.\n\nOutput collection:\n// Set up stdout capture\npyodide.setStdout({\n  batched: (output: string) => {\n    const type = output.startsWith("data:image/png;base64")\n      ? "image"\n      : "data";\n    logs.push({ type: "log", args: [{ type, value: output }] });\n  },\n});\n\npyodide.setStderr({\n  batched: (output: string) => {\n    logs.push({ type: "error", args: [{ type: "data", value: output }] });\n  },\n});`,
+      description: `Execute Python code in the user's browser via Pyodide.\n\nNetwork access: use pyodide.http.open_url for HTTP/HTTPS, not urllib/request/requests. CORS must allow the app origin.\nExample (CSV):\nfrom pyodide.http import open_url\nimport pandas as pd\nurl = 'https://example.com/data.csv'\ndf = pd.read_csv(open_url(url))\nprint(df.head())\n\nOutput capture:\npyodide.setStdout({\n  batched: (output: string) => {\n    const type = output.startsWith('data:image/png;base64') ? 'image' : 'data'\n    logs.push({ type: 'log', args: [{ type, value: output }] })\n  },\n})\npyodide.setStderr({\n  batched: (output: string) => {\n    logs.push({ type: 'error', args: [{ type: 'data', value: output }] })\n  },\n})`,
     },
   },
   required: ["code"],
@@ -15,6 +15,6 @@ export const pythonExecutionSchema: JSONSchema7 = {
 
 export const pythonExecutionTool = createTool({
   description:
-    "Execute Python code directly in the user's browser using Pyodide. Code runs client-side without server dependency.",
+    "Execute Python code in the user's browser via Pyodide. Use pyodide.http.open_url for HTTP(S) downloads; CORS must allow the app origin.",
   inputSchema: jsonSchemaToZod(pythonExecutionSchema),
 });

--- a/src/lib/file-ingest/csv.test.ts
+++ b/src/lib/file-ingest/csv.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { formatCsvPreviewText, parseCsvPreview } from "./csv";
+
+describe("parseCsvPreview", () => {
+  it("parses simple CSV and limits rows/cols", () => {
+    const csv = "a,b,c\n1,2,3\n4,5,6\n7,8,9\n";
+    const res = parseCsvPreview(Buffer.from(csv), { maxRows: 2, maxCols: 2 });
+    expect(res.header).toEqual(["a", "b"]);
+    expect(res.rows).toEqual([
+      ["1", "2"],
+      ["4", "5"],
+    ]);
+    expect(res.columns).toBe(2);
+    expect(res.totalRows).toBe(4); // includes header
+    expect(res.markdownTable).toContain("| a | b |");
+  });
+
+  it("handles quoted fields and escaped quotes", () => {
+    const csv = 'name,desc\n"ACME, Inc.","He said ""hello"""\n';
+    const res = parseCsvPreview(Buffer.from(csv));
+    expect(res.header).toEqual(["name", "desc"]);
+    expect(res.rows[0]).toEqual(["ACME, Inc.", 'He said "hello"']);
+  });
+
+  it("formats preview text with summary metadata", () => {
+    const csv = "col1,col2\n1,2\n3,4\n";
+    const preview = parseCsvPreview(Buffer.from(csv));
+    const text = formatCsvPreviewText("sample.csv", preview);
+    expect(text).toContain("sample.csv");
+    expect(text).toContain("rows: 3");
+    expect(text).toContain("cols: 2");
+    expect(text).toContain("| col1 | col2 |");
+  });
+});

--- a/src/lib/file-ingest/csv.ts
+++ b/src/lib/file-ingest/csv.ts
@@ -61,7 +61,7 @@ export function parseCsvPreview(
   }
   // flush last field/row
   pushField();
-  if (row.length > 1 || row[0] !== "") pushRow();
+  if (row.some(field => field !== "")) pushRow();
 
   const totalRows = rows.length;
   const header = rows[0] ?? [];

--- a/src/lib/file-ingest/csv.ts
+++ b/src/lib/file-ingest/csv.ts
@@ -1,0 +1,98 @@
+import { Buffer } from "node:buffer";
+
+export type CsvPreview = {
+  header: string[];
+  rows: string[][]; // limited by maxRows/maxCols
+  columns: number;
+  totalRows: number;
+  markdownTable: string; // simple markdown table for the chat
+};
+
+export function parseCsvPreview(
+  content: Buffer,
+  opts: { maxRows?: number; maxCols?: number } = {},
+): CsvPreview {
+  const maxRows = Math.max(1, opts.maxRows ?? 50);
+  const maxCols = Math.max(1, opts.maxCols ?? 12);
+  const text = content.toString("utf8");
+
+  const rows: string[][] = [];
+  let i = 0;
+  let field = "";
+  let inQuotes = false;
+  let row: string[] = [];
+
+  const pushField = () => {
+    row.push(field);
+    field = "";
+  };
+  const pushRow = () => {
+    rows.push(row);
+    row = [];
+  };
+
+  while (i < text.length) {
+    const ch = text[i++];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += ch;
+      }
+    } else {
+      if (ch === '"') {
+        inQuotes = true;
+      } else if (ch === ",") {
+        pushField();
+      } else if (ch === "\n") {
+        pushField();
+        pushRow();
+      } else if (ch === "\r") {
+        // ignore CR (handle CRLF)
+      } else {
+        field += ch;
+      }
+    }
+  }
+  // flush last field/row
+  pushField();
+  if (row.length > 1 || row[0] !== "") pushRow();
+
+  const totalRows = rows.length;
+  const header = rows[0] ?? [];
+  const limitedHeader = header.slice(0, maxCols);
+  const dataRows = rows.slice(1);
+  const limitedRows = dataRows
+    .slice(0, maxRows)
+    .map((r) => r.slice(0, maxCols));
+  const columns = limitedHeader.length;
+
+  const mdHeader = `| ${limitedHeader.join(" | ")} |`;
+  const mdSep = `| ${limitedHeader.map(() => "---").join(" | ")} |`;
+  const mdBody = limitedRows
+    .map(
+      (r) => `| ${r.map((c) => (c ?? "").replace(/\|/g, "\\|")).join(" | ")} |`,
+    )
+    .join("\n");
+  const markdownTable = [mdHeader, mdSep, mdBody].join("\n");
+
+  return {
+    header: limitedHeader,
+    rows: limitedRows,
+    columns,
+    totalRows,
+    markdownTable,
+  };
+}
+
+export const formatCsvPreviewText = (
+  name: string,
+  preview: CsvPreview,
+): string => {
+  return `Here is a preview of ${name} (rows: ${preview.totalRows}, cols: ${preview.columns}). Summarize or analyze as needed.\n\n${preview.markdownTable}`;
+};

--- a/src/lib/file-storage/s3-file-storage.test.ts
+++ b/src/lib/file-storage/s3-file-storage.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: vi.fn(
+    async (_c, _cmd, { expiresIn }: any) =>
+      `https://example.com/presigned?exp=${expiresIn}`,
+  ),
+}));
+
+const sendMock = vi.fn();
+
+vi.mock("@aws-sdk/client-s3", () => {
+  class BaseCmd {
+    constructor(public input: any) {}
+  }
+  return {
+    S3Client: vi.fn().mockImplementation(() => ({ send: sendMock })),
+    PutObjectCommand: class extends BaseCmd {},
+    GetObjectCommand: class extends BaseCmd {},
+    DeleteObjectCommand: class extends BaseCmd {},
+    HeadObjectCommand: class extends BaseCmd {},
+  };
+});
+
+import { createS3FileStorage } from "./s3-file-storage";
+
+describe("s3-file-storage", () => {
+  beforeEach(() => {
+    sendMock.mockReset();
+    process.env.FILE_STORAGE_S3_BUCKET = "my-bucket";
+    process.env.FILE_STORAGE_S3_REGION = "us-east-2";
+    process.env.FILE_STORAGE_PREFIX = "uploads";
+    delete process.env.FILE_STORAGE_S3_PUBLIC_BASE_URL;
+    delete process.env.FILE_STORAGE_S3_ENDPOINT;
+    delete process.env.FILE_STORAGE_S3_FORCE_PATH_STYLE;
+  });
+
+  it("uploads and returns sourceUrl + metadata", async () => {
+    // PutObject ok
+    sendMock.mockResolvedValueOnce({});
+    const storage = createS3FileStorage();
+    const res = await storage.upload(Buffer.from("abc"), {
+      filename: "file.txt",
+      contentType: "text/plain",
+    });
+    expect(res.key).toMatch(/^uploads\//);
+    expect(res.sourceUrl).toMatch(
+      /^https:\/\/my-bucket.s3.us-east-2.amazonaws.com\//,
+    );
+    expect(res.metadata.size).toBe(3);
+  });
+
+  it("createUploadUrl returns PUT and headers", async () => {
+    const storage = createS3FileStorage();
+    const out = await storage.createUploadUrl!({
+      filename: "img.png",
+      contentType: "image/png",
+      expiresInSeconds: 600,
+    });
+    expect(out?.method).toBe("PUT");
+    expect(out?.headers).toEqual({ "Content-Type": "image/png" });
+    expect(out?.url).toContain("exp=600");
+  });
+
+  it("exists returns true/false via HeadObject", async () => {
+    const storage = createS3FileStorage();
+    // true
+    sendMock.mockResolvedValueOnce({});
+    expect(await storage.exists("uploads/a.txt")).toBe(true);
+    // false
+    const err: any = new Error("not found");
+    err.$metadata = { httpStatusCode: 404 };
+    sendMock.mockRejectedValueOnce(err);
+    expect(await storage.exists("uploads/missing.txt")).toBe(false);
+  });
+
+  it("getMetadata maps fields", async () => {
+    const storage = createS3FileStorage();
+    sendMock.mockResolvedValueOnce({
+      ContentType: "text/plain",
+      ContentLength: 10,
+      LastModified: new Date("2020-01-01"),
+    });
+    const meta = await storage.getMetadata("uploads/x.txt");
+    expect(meta?.contentType).toBe("text/plain");
+    expect(meta?.size).toBe(10);
+  });
+
+  it("getSourceUrl respects PUBLIC_BASE_URL when set", async () => {
+    process.env.FILE_STORAGE_S3_PUBLIC_BASE_URL = "https://cdn.example.com";
+    const storage = createS3FileStorage();
+    const url = await storage.getSourceUrl("uploads/x.txt");
+    expect(url).toBe("https://cdn.example.com/uploads/x.txt");
+  });
+});

--- a/src/lib/file-storage/s3-file-storage.ts
+++ b/src/lib/file-storage/s3-file-storage.ts
@@ -1,16 +1,222 @@
-import { NotImplementedError } from "lib/errors";
-import type { FileStorage } from "./file-storage.interface";
+import path from "node:path";
+import {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+  DeleteObjectCommand,
+  HeadObjectCommand,
+} from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import type {
+  FileMetadata,
+  FileStorage,
+  UploadOptions,
+  UploadUrl,
+  UploadUrlOptions,
+} from "./file-storage.interface";
+import {
+  resolveStoragePrefix,
+  sanitizeFilename,
+  toBuffer,
+} from "./storage-utils";
+import { FileNotFoundError } from "lib/errors";
+import { generateUUID } from "lib/utils";
 
-/**
- * Placeholder for an Amazon S3 (or S3-compatible) storage backend.
- *
- * When you implement this driver, consider:
- * - Reading configuration from FILE_STORAGE_S3_BUCKET / FILE_STORAGE_S3_REGION / FILE_STORAGE_PREFIX
- * - Mapping the FileStorage contract onto S3 operations (PutObject, GetObject, DeleteObject, HeadObject, etc.)
- * - Supporting presigned upload URLs when client-side uploads are required
- */
+const STORAGE_PREFIX = resolveStoragePrefix();
+
+const required = (name: string, value: string | undefined) => {
+  if (!value) throw new Error(`Missing required env: ${name}`);
+  return value;
+};
+
+const buildKey = (filename: string) => {
+  const safeName = sanitizeFilename(filename || "file");
+  const id = generateUUID();
+  const prefix = STORAGE_PREFIX ? `${STORAGE_PREFIX}/` : "";
+  return path.posix.join(prefix, `${id}-${safeName}`);
+};
+
+const buildPublicUrl = (
+  bucket: string,
+  region: string,
+  key: string,
+  publicBaseUrl?: string,
+  endpoint?: string,
+  forcePathStyle?: boolean,
+) => {
+  if (publicBaseUrl) {
+    return `${publicBaseUrl.replace(/\/$/, "")}/${encodeURI(key)}`;
+  }
+
+  // If custom endpoint provided (e.g., MinIO), fall back to constructing from it
+  if (endpoint) {
+    const base = endpoint.replace(/\/$/, "");
+    if (forcePathStyle) return `${base}/${bucket}/${encodeURI(key)}`;
+    try {
+      const u = new URL(base);
+      return `${u.protocol}//${bucket}.${u.host}/${encodeURI(key)}`;
+    } catch {
+      return `${base}/${bucket}/${encodeURI(key)}`;
+    }
+  }
+
+  // AWS standard virtual-hosted–style URL
+  return `https://${bucket}.s3.${region}.amazonaws.com/${encodeURI(key)}`;
+};
+
 export const createS3FileStorage = (): FileStorage => {
-  throw new NotImplementedError(
-    "S3 storage driver not implemented. Implement createS3FileStorage before enabling FILE_STORAGE_TYPE=s3.",
+  const bucket = required(
+    "FILE_STORAGE_S3_BUCKET",
+    process.env.FILE_STORAGE_S3_BUCKET,
   );
+  const region = process.env.FILE_STORAGE_S3_REGION || process.env.AWS_REGION;
+  if (!region)
+    throw new Error(
+      "Missing required env: FILE_STORAGE_S3_REGION or AWS_REGION",
+    );
+  const endpoint = process.env.FILE_STORAGE_S3_ENDPOINT;
+  const forcePathStyle = /^1|true$/i.test(
+    process.env.FILE_STORAGE_S3_FORCE_PATH_STYLE || "",
+  );
+  const publicBaseUrl = process.env.FILE_STORAGE_S3_PUBLIC_BASE_URL;
+
+  const s3 = new S3Client({
+    region,
+    endpoint,
+    forcePathStyle,
+  });
+
+  return {
+    async upload(content, options: UploadOptions = {}) {
+      const buffer = await toBuffer(content);
+      const filename = options.filename ?? "file";
+      const key = buildKey(filename);
+
+      await s3.send(
+        new PutObjectCommand({
+          Bucket: bucket,
+          Key: key,
+          Body: buffer,
+          ContentType: options.contentType,
+          ACL: undefined, // rely on bucket policy for public/private
+        }),
+      );
+
+      const metadata: FileMetadata = {
+        key,
+        filename: path.posix.basename(key),
+        contentType: options.contentType || "application/octet-stream",
+        size: buffer.byteLength,
+        uploadedAt: new Date(),
+      };
+
+      const sourceUrl = buildPublicUrl(
+        bucket,
+        region,
+        key,
+        publicBaseUrl,
+        endpoint,
+        forcePathStyle,
+      );
+
+      return { key, sourceUrl, metadata };
+    },
+
+    async createUploadUrl(
+      options: UploadUrlOptions,
+    ): Promise<UploadUrl | null> {
+      const key = buildKey(options.filename);
+      const command = new PutObjectCommand({
+        Bucket: bucket,
+        Key: key,
+        ContentType: options.contentType,
+      });
+      const expires = Math.max(
+        60,
+        Math.min(60 * 60 * 12, options.expiresInSeconds ?? 900),
+      );
+      const url = await getSignedUrl(s3, command, { expiresIn: expires });
+      return {
+        key,
+        url,
+        method: "PUT",
+        expiresAt: new Date(Date.now() + expires * 1000),
+        headers: { "Content-Type": options.contentType },
+      };
+    },
+
+    async download(key) {
+      try {
+        const res = await s3.send(
+          new GetObjectCommand({ Bucket: bucket, Key: key }),
+        );
+        const body = res.Body;
+        if (!body) throw new FileNotFoundError(key);
+        const stream = body as unknown as NodeJS.ReadableStream;
+        const chunks: Buffer[] = [];
+        await new Promise<void>((resolve, reject) => {
+          stream.on("data", (c) =>
+            chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c)),
+          );
+          stream.once("end", () => resolve());
+          stream.once("error", (e) => reject(e));
+        });
+        return Buffer.concat(chunks);
+      } catch (error: unknown) {
+        if ((error as any)?.$metadata?.httpStatusCode === 404) {
+          throw new FileNotFoundError(key, error);
+        }
+        throw error;
+      }
+    },
+
+    async delete(key) {
+      await s3.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }));
+    },
+
+    async exists(key) {
+      try {
+        await s3.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+        return true;
+      } catch (error: unknown) {
+        if ((error as any)?.$metadata?.httpStatusCode === 404) return false;
+        return false;
+      }
+    },
+
+    async getMetadata(key) {
+      try {
+        const res = await s3.send(
+          new HeadObjectCommand({ Bucket: bucket, Key: key }),
+        );
+        return {
+          key,
+          filename: path.posix.basename(key),
+          contentType: res.ContentType || "application/octet-stream",
+          size: Number(res.ContentLength || 0),
+          uploadedAt: res.LastModified ?? undefined,
+        } satisfies FileMetadata;
+      } catch (error: unknown) {
+        if ((error as any)?.$metadata?.httpStatusCode === 404) return null;
+        throw error;
+      }
+    },
+
+    async getSourceUrl(key) {
+      return buildPublicUrl(
+        bucket,
+        region,
+        key,
+        publicBaseUrl,
+        endpoint,
+        forcePathStyle,
+      );
+    },
+
+    async getDownloadUrl(key) {
+      const command = new GetObjectCommand({ Bucket: bucket, Key: key });
+      const url = await getSignedUrl(s3, command, { expiresIn: 3600 });
+      return url;
+    },
+  } satisfies FileStorage;
 };

--- a/src/lib/file-storage/storage-utils.test.ts
+++ b/src/lib/file-storage/storage-utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { storageKeyFromUrl } from "./storage-utils";
+
+describe("storageKeyFromUrl", () => {
+  it("extracts key from absolute URL", () => {
+    expect(storageKeyFromUrl("https://example.com/uploads/sample.csv")).toBe(
+      "uploads/sample.csv",
+    );
+  });
+
+  it("decodes encoded path segments", () => {
+    expect(
+      storageKeyFromUrl(
+        "https://example.com/uploads/My%20File%20(1).csv?token=123",
+      ),
+    ).toBe("uploads/My File (1).csv");
+  });
+
+  it("returns null for invalid URLs", () => {
+    expect(storageKeyFromUrl("not-a-url")).toBeNull();
+  });
+});

--- a/src/lib/file-storage/storage-utils.ts
+++ b/src/lib/file-storage/storage-utils.ts
@@ -73,6 +73,15 @@ export const resolveStoragePrefix = () => {
   return raw.replace(/^\/+|\/+$|\.+/g, "").trim();
 };
 
+export const storageKeyFromUrl = (input: string): string | null => {
+  try {
+    const url = new URL(input);
+    return decodeURIComponent(url.pathname.replace(/^\//, ""));
+  } catch {
+    return null;
+  }
+};
+
 const isArrayBufferLike = (value: unknown): value is ArrayBuffer =>
   value instanceof ArrayBuffer;
 

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -17,6 +17,15 @@ export type ChatModel = {
   model: string;
 };
 
+export const ChatAttachmentSchema = z.object({
+  type: z.enum(["file", "source-url"]),
+  url: z.string(),
+  mediaType: z.string().optional(),
+  filename: z.string().optional(),
+});
+
+export type ChatAttachment = z.infer<typeof ChatAttachmentSchema>;
+
 export type ChatThread = {
   id: string;
   title: string;
@@ -98,6 +107,7 @@ export const chatApiSchemaRequestBodySchema = z.object({
   imageTool: z.object({ model: z.string().optional() }).optional(),
   allowedMcpServers: z.record(z.string(), AllowedMCPServerZodSchema).optional(),
   allowedAppDefaultToolkit: z.array(z.string()).optional(),
+  attachments: z.array(ChatAttachmentSchema).optional(),
 });
 
 export type ChatApiSchemaRequestBody = z.infer<


### PR DESCRIPTION
## Summary

- Stand up a production-ready S3 storage driver: presigned PUT upload flow, head/tail download helpers, CLI smoke check, new env surface area, and doc updates for
  teams migrating off Vercel Blob.
- Rebuild the upload UX into a thread-scoped, multi-file pipeline with drag-and-drop overlay, retry-aware queueing, per-file progress, and consistent metadata fan-
  out for chat state, clipboard, and API payloads.
- Normalize attachment rendering so user vs. assistant bubbles style correctly, filenames truncate, filetype badges surface, and download affordances remain obvious
  —even when multiple cards stack together.
- Tighten the file-handling contract: only image/PDF MIME types flow through as file parts; everything else gracefully downgrades to a source-url card so models
  never receive unsupported media. CSV is special-cased with a hidden markdown preview that the model consumes while the UI stays clean.
- Advertise per-model MIME capabilities through customModelProvider, letting the composer warn early and making unsupported models fall back without breaking tool
  calls.
- Auto-ingest CSV attachments by streaming server-side previews, plugging into chat history so agents can immediately cite tabular context. Added coverage for
  preview formatting and ingestion gating.
- Document the new storage story (docs/storage/s3-setup.md) and codex agent metadata (AGENTS.md), plus extend unit tests across storage utils, ingestion, and MIME
  support.

### File Handling Model

- Provider MIME gates: The client now trusts explicit allowlists attached to each model. If a provider (e.g., OpenAI) cannot ingest a media type, we flip the part
  to source-url so the LLM sees a link instead of throwing “functionality not supported.” This keeps uploads future-proof and highlights the narrow set of formats
  we genuinely support today (images + PDF).
- CSV ingestion preview: CSV files render an ingestionPreview text part that the UI suppresses but the model consumes, giving instant structured context without
  polluting the chat transcript.
- Threaded uploader: Each thread maintains its own queue, enabling parallel uploads, progress tracking, and safe retry semantics. Drag-and-drop, button uploads, and
  clipboard pastes all flow through a single hook so we don’t double-handle state.
- UI parity: File bubbles respect author context, maintain readability with truncation and badges, and keep download buttons consistent even when stacking multiple
  attachments.

## Screenshots / Recordings

### Drag and Drop
https://github.com/user-attachments/assets/1346b0e7-fa86-4a8f-abee-bd69542c93b9

### Multi File Drag and Drop
https://github.com/user-attachments/assets/d3e3bd27-6cee-4ac4-86f6-b08bc1ce5973

### CSV Preview
https://github.com/user-attachments/assets/9382005f-ea50-4377-9e15-34d3bb88c7fc

## Configuration Notes

- .env.example now documents FILE_STORAGE_TYPE (vercel-blob or s3), FILE_STORAGE_S3_BUCKET, region, optional CDN origin, and other S3 knobs.
- S3 driver uses AWS credentials from env or the default provider chain; fallback instructions live in docs/storage/s3-setup.md.
- CSV ingestion continues to leverage /api/storage/ingest; ensure your storage backend serves direct downloads for the preview step.

## Verification Guide

1. pnpm dev
2. Upload a mix of image + CSV + PDF via the picker and via drag-and-drop. Confirm badges, truncation, download button, and per-thread queues.
3. Switch to a model that doesn’t support file parts; ensure attachments render as “source-url” cards instead of failing tool calls.
4. Send a CSV attachment and validate the assistant references the preview immediately with no visible summary text in the chat.
5. (Optional) Point to S3 credentials, generate a presigned PUT (CLI script provided), upload through the UI, and confirm the file is present via S3 console or aws
    s3 head object.

## Tests

- pnpm format
- pnpm lint
- pnpm check-types
- pnpm test

## Documentation & Follow-up

- New S3 setup guide at docs/storage/s3-setup.md.
- Added AGENTS.md for Codex agent metadata.
- Future: add XLSX ingestion once a server-side parser/vectorization pipeline lands; capture upload telemetry once S3 analytics hooks are in place.