### PR TITLE
feat: Add markdown download button to message actions

### DIFF
--- a/src/components/message-parts.tsx
+++ b/src/components/message-parts.tsx
@@ -359,6 +359,24 @@ export const AssistMessagePart = memo(function AssistMessagePart({
       .unwrap();
   };
 
+  const downloadMarkdown = useCallback(() => {
+    const timestamp = new Date()
+      .toISOString()
+      .replace(/[:.]/g, "-")
+      .slice(0, 19);
+    const filename = `response-${timestamp}.md`;
+
+    const blob = new Blob([part.text], { type: "text/markdown;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, [part.text]);
+
   return (
     <div
       className={cn(
@@ -389,6 +407,20 @@ export const AssistMessagePart = memo(function AssistMessagePart({
               </Button>
             </TooltipTrigger>
             <TooltipContent>Copy</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                data-testid="message-download-button"
+                variant="ghost"
+                size="icon"
+                className="size-3! p-4!"
+                onClick={downloadMarkdown}
+              >
+                <Download />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Download Markdown</TooltipContent>
           </Tooltip>
           {!readonly && (
             <>


### PR DESCRIPTION
## Summary

Adds a download button next to the copy button in assistant messages, allowing users to save markdown responses as `.md` files with one click.

## Motivation

Currently, users need to manually copy markdown content and paste it into a text editor to save it. This adds friction when users want to:
- Archive AI responses for later reference
- Build documentation from chat conversations
- Share responses as markdown files

This feature makes saving markdown content as effortless as the existing copy functionality.

## Changes

- Added `downloadMarkdown` function in `AssistMessagePart` component
- Added Download button to message action buttons (appears on hover with Copy/Change Model/Delete)
- Downloads files with timestamped filenames: `response-2025-11-04T12-30-45.md`
- Uses proper MIME type: `text/markdown;charset=utf-8`
- Consistent styling with existing action buttons

## Implementation Details

**File Modified**: `src/components/message-parts.tsx`
- Lines added: ~27
- No new dependencies required
- Download icon already imported from `lucide-react`
- Follows existing button pattern (tooltip, styling, event handling)

## Testing

- [x] Button appears on message hover
- [x] Download triggers correctly
- [x] File has correct `.md` extension
- [x] Content matches markdown exactly
- [x] Filename is unique (timestamped)
- [x] Tooltip displays correctly
- [x] Works in both light and dark themes

## Screenshots

### Download button in action


<img width="1108" height="952" alt="download-markdown" src="https://github.com/user-attachments/assets/c11e1c87-e252-4bdb-b85c-662a959529c0" />


*Download icon appears between Copy and Change Model buttons*

## Related

- Closes discussion about file generation (decided to start with simple markdown download first)
- Complements existing Copy button functionality
- Similar pattern to table export feature

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>