### PR TITLE
fix: hide MCP server credentials from non-owners (#317)

### DIFF
--- a/src/app/api/mcp/list/route.ts
+++ b/src/app/api/mcp/list/route.ts
@@ -42,8 +42,11 @@ export async function GET() {
   const result = servers.map((server) => {
     const mem = memoryMap.get(server.id);
     const info = mem?.getInfo();
+    const isOwner = server.userId === currentUser.id;
     const mcpInfo: MCPServerInfo = {
       ...server,
+      // Hide config from non-owners to prevent credential exposure
+      config: isOwner ? server.config : undefined,
       enabled: info?.enabled ?? true,
       status: info?.status ?? "connected",
       error: info?.error,

--- a/src/components/mcp-card.tsx
+++ b/src/components/mcp-card.tsx
@@ -303,19 +303,24 @@ export const MCPCard = memo(function MCPCard({
 
       <div className="relative hidden sm:flex w-full">
         <CardContent className="flex min-w-0 w-full flex-row text-sm max-h-[320px] overflow-hidden border-r-0">
-          <div className="w-1/2 min-w-0 flex flex-col pr-2 border-r border-border">
-            <div className="flex items-center gap-2 mb-2 pt-2 pb-1 z-10">
-              <Settings size={14} className="text-muted-foreground" />
-              <h5 className="text-muted-foreground text-sm font-medium">
-                {t("configuration")}
-              </h5>
+          {/* Only show config to owners to prevent credential exposure */}
+          {isOwner && config && (
+            <div className="w-1/2 min-w-0 flex flex-col pr-2 border-r border-border">
+              <div className="flex items-center gap-2 mb-2 pt-2 pb-1 z-10">
+                <Settings size={14} className="text-muted-foreground" />
+                <h5 className="text-muted-foreground text-sm font-medium">
+                  {t("configuration")}
+                </h5>
+              </div>
+              <div className="flex-1 overflow-y-auto">
+                <JsonView data={config} />
+              </div>
             </div>
-            <div className="flex-1 overflow-y-auto">
-              <JsonView data={config} />
-            </div>
-          </div>
+          )}
 
-          <div className="w-1/2 min-w-0 flex flex-col pl-4">
+          <div
+            className={`${isOwner && config ? "w-1/2" : "w-full"} min-w-0 flex flex-col ${isOwner && config ? "pl-4" : ""}`}
+          >
             <div className="flex items-center gap-2 mb-4 pt-2 pb-1 z-10">
               <Wrench size={14} className="text-muted-foreground" />
               <h5 className="text-muted-foreground text-sm font-medium">

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -42,7 +42,7 @@ export type MCPToolInfo = {
 export type MCPServerInfo = {
   id: string;
   name: string;
-  config: MCPServerConfig;
+  config?: MCPServerConfig; // Optional - hidden from non-owners for security
   visibility: "public" | "private";
   error?: unknown;
   enabled: boolean;


### PR DESCRIPTION
Fixes credential exposure when MCP servers are shared publicly.

## Problem
When `visibility="public"`, config JSON (including bearer tokens and API keys) was visible to all users via both API responses and UI display.

## Solution
- Filter `config` from API responses for non-owners
- Hide config panel in UI for non-owners  
- Expand tools panel to full width when config hidden

## Changes
- `src/types/mcp.ts`: Made config optional in MCPServerInfo
- `src/app/api/mcp/list/route.ts`: Filter config based on ownership
- `src/components/mcp-card.tsx`: Conditional config display

## Result
- ✅ Owners: Full config access maintained
- ✅ Non-owners: Can use servers but cannot see credentials
- ✅ Backward compatible with existing data
- ✅ No database changes required

## Testing
Tested with two users - owner can see config, non-owner cannot.

Fixes #317