### PR TITLE
fix: skip signup method selection when only email is enabled

### DIFF
--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -14,11 +14,17 @@ export default async function SignUp() {
   if (!signUpEnabled) {
     redirect("/sign-in");
   }
+
   const enabledProviders = (
     Object.keys(
       socialAuthenticationProviders,
     ) as (keyof typeof socialAuthenticationProviders)[]
   ).filter((key) => socialAuthenticationProviders[key]);
+
+  if (emailAndPasswordEnabled && enabledProviders.length === 0) {
+    redirect("/sign-up/email");
+  }
+
   return (
     <SignUpPage
       isFirstUser={isFirstUser}


### PR DESCRIPTION
When only email authentication is enabled (no social providers), the sign-up flow now redirects directly to /sign-up/email instead of showing an intermediate page with a single "Email" button.

**Before**

<img width="528" height="251" alt="image" src="https://github.com/user-attachments/assets/2b4bbf8e-eeb1-471b-805b-976659f0c463" />

An intermediate page with only an "Email" button is displayed when the user clicks "Sign up". 

**After**

<img width="522" height="378" alt="image" src="https://github.com/user-attachments/assets/201fab60-7d67-4ba5-a29c-394790d758e5" />

The sign up form is immediately displayed when the user clicks "Sign up" when only email authentication is enabled.
