### PR TITLE
fix: use translation for user settings menu item

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -379,7 +379,8 @@
     "showAllChats": "View All Chats",
     "showLessChats": "Show less",
     "reportAnIssue": "Report an issue",
-    "joinCommunity": "Join Community"
+    "joinCommunity": "Join Community",
+    "userSettings": "User Settings"
   },
   "Archive": {
     "title": "Archive",

--- a/messages/es.json
+++ b/messages/es.json
@@ -187,7 +187,8 @@
       "userInstructions": "Instrucciones de Usuario",
       "userInstructionsDescription": "Preséntate y obtén una respuesta más personalizada.",
       "mcpInstructions": "Instrucciones MCP",
-      "mcpInstructionsDescription": "Personaliza las instrucciones del servidor MCP."
+      "mcpInstructionsDescription": "Personaliza las instrucciones del servidor MCP.",
+      "userSettings": "Configuración de Usuario"
     }
   },
   "Layout": {
@@ -238,7 +239,8 @@
     "showLessChats": "Mostrar menos",
     "reportAnIssue": "Reportar un problema",
     "joinCommunity": "Unirse a la Comunidad",
-    "workflow": "Flujo de Trabajo"
+    "workflow": "Flujo de Trabajo",
+    "userSettings": "Configuración de Usuario"
   },
   "Archive": {
     "title": "Archivo",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -187,7 +187,8 @@
       "userInstructions": "Instructions Utilisateur",
       "userInstructionsDescription": "Présentez-vous et obtenez une réponse plus personnalisée.",
       "mcpInstructions": "Instructions MCP",
-      "mcpInstructionsDescription": "Personnalisez les instructions du serveur MCP."
+      "mcpInstructionsDescription": "Personnalisez les instructions du serveur MCP.",
+      "userSettings": "Paramètres Utilisateur"
     }
   },
   "Layout": {
@@ -238,7 +239,8 @@
     "showLessChats": "Afficher moins",
     "reportAnIssue": "Signaler un problème",
     "joinCommunity": "Rejoindre la Communauté",
-    "workflow": "Flux de Travail"
+    "workflow": "Flux de Travail",
+    "userSettings": "Paramètres Utilisateur"
   },
   "Archive": {
     "title": "Archive",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -187,7 +187,8 @@
       "userInstructions": "ユーザー指示",
       "userInstructionsDescription": "自己紹介をして、よりパーソナライズされた回答を受け取りましょう。",
       "mcpInstructions": "MCP 指示",
-      "mcpInstructionsDescription": "MCP サーバーの指示をカスタマイズします。"
+      "mcpInstructionsDescription": "MCP サーバーの指示をカスタマイズします。",
+      "userSettings": "ユーザー設定"
     }
   },
   "Layout": {
@@ -237,7 +238,8 @@
     "showLessChats": "少なく表示",
     "reportAnIssue": "問題を報告",
     "joinCommunity": "コミュニティに参加",
-    "workflow": "ワークフロー"
+    "workflow": "ワークフロー",
+    "userSettings": "ユーザー設定"
   },
   "Archive": {
     "title": "アーカイブ",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -202,7 +202,8 @@
       "linkCopied": "링크가 클립보드에 복사되었습니다",
       "confirmDeleteExport": "이 공유를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
       "exportDeleted": "공유가 성공적으로 삭제되었습니다",
-      "failedToDeleteExport": "공유 삭제에 실패했습니다"
+      "failedToDeleteExport": "공유 삭제에 실패했습니다",
+      "userSettings": "사용자 설정"
     }
   },
   "Layout": {
@@ -252,7 +253,8 @@
     "showAllChats": "모든 채팅",
     "showLessChats": "간략히 보기",
     "reportAnIssue": "도움 받기",
-    "joinCommunity": "커뮤니티 가입"
+    "joinCommunity": "커뮤니티 가입",
+    "userSettings": "사용자 설정"
   },
   "Archive": {
     "title": "아카이브",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -186,7 +186,8 @@
       "userInstructions": "用户说明",
       "userInstructionsDescription": "介绍自己并获得更个性化的回应。",
       "mcpInstructions": "MCP 说明",
-      "mcpInstructionsDescription": "自定义 MCP 服务器说明。"
+      "mcpInstructionsDescription": "自定义 MCP 服务器说明。",
+      "userSettings": "用户设置"
     }
   },
   "Layout": {
@@ -236,7 +237,8 @@
     "showLessChats": "显示更少",
     "reportAnIssue": "报告问题",
     "joinCommunity": "加入社区",
-    "workflow": "工作流"
+    "workflow": "工作流",
+    "userSettings": "用户设置"
   },
   "Archive": {
     "title": "归档",

--- a/src/components/layouts/app-sidebar-user.tsx
+++ b/src/components/layouts/app-sidebar-user.tsx
@@ -164,7 +164,7 @@ export function AppSidebarUserInner(props: {
               data-testid="user-settings-menu-item"
             >
               <Settings className="size-4 text-foreground" />
-              <span>User Settings</span>
+              <span>{t("userSettings")}</span>
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={logout} className="cursor-pointer">


### PR DESCRIPTION
Replace hardcoded "User Settings" string with translation key in sidebar user menu and add missing translations.