### PR TITLE
fix: redirect authenticated users from auth pages to home

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -2,10 +2,16 @@ import { Think } from "ui/think";
 import { getTranslations } from "next-intl/server";
 import { FlipWords } from "ui/flip-words";
 import { BackgroundPaths } from "ui/background-paths";
+import { getSession } from "lib/auth/server";
+import { redirect } from "next/navigation";
 
 export default async function AuthLayout({
   children,
 }: { children: React.ReactNode }) {
+  const session = await getSession();
+  if (session) {
+    redirect("/");
+  }
   const t = await getTranslations("Auth.Intro");
   return (
     <main className="relative w-full flex flex-col h-screen">

--- a/src/lib/auth/auth-instance.ts
+++ b/src/lib/auth/auth-instance.ts
@@ -120,15 +120,12 @@ export const auth = betterAuth({
 });
 
 export const getSession = async () => {
+  const reqHeaders = await headers();
   try {
     const session = await auth.api.getSession({
-      headers: await headers(),
+      headers: reqHeaders,
     });
-    if (!session) {
-      logger.error("No session found");
-      return null;
-    }
-    return session;
+    return session ?? null;
   } catch (error) {
     logger.error("Error getting session:", error);
     return null;


### PR DESCRIPTION
Authenticated users visiting `/sign-in` or `/sign-up` are now redirected to `/`.