### PR TITLE
fix: derive current user in password reset

### DIFF
--- a/src/app/api/user/actions.ts
+++ b/src/app/api/user/actions.ts
@@ -177,14 +177,8 @@ export const updateUserPasswordAction = validatedActionWithUserManagePermission(
     _formData,
   ): Promise<UpdateUserPasswordActionState> => {
     const t = await getTranslations("User.Profile.common");
-    const {
-      newPassword,
-      isCurrentUser: isCurrentUserParam,
-      currentPassword,
-    } = data;
+    const { newPassword, currentPassword } = data;
     const { hasPassword } = await getUserAccounts(userId);
-
-    const isCurrentUser = isCurrentUserParam ? isOwnResource : false;
 
     if (!hasPassword) {
       return {
@@ -194,7 +188,7 @@ export const updateUserPasswordAction = validatedActionWithUserManagePermission(
     }
 
     try {
-      if (isCurrentUser) {
+      if (isOwnResource) {
         if (!currentPassword) {
           return {
             success: false,

--- a/src/app/api/user/validations.test.ts
+++ b/src/app/api/user/validations.test.ts
@@ -213,7 +213,6 @@ describe("User Validations", () => {
     it("should validate correct password data", () => {
       const validData = {
         userId: "123e4567-e89b-12d3-a456-426614174000",
-        isCurrentUser: false,
         newPassword: "SecurePass123!",
         confirmPassword: "SecurePass123!",
       };
@@ -228,7 +227,6 @@ describe("User Validations", () => {
     it("should reject when passwords do not match", () => {
       const invalidData = {
         userId: "123e4567-e89b-12d3-a456-426614174000",
-        isCurrentUser: false,
         newPassword: "SecurePass123!",
         confirmPassword: "DifferentPass123!",
       };
@@ -245,7 +243,6 @@ describe("User Validations", () => {
     it("should reject invalid UUID", () => {
       const invalidData = {
         userId: "not-a-uuid",
-        isCurrentUser: false,
         newPassword: "SecurePass123!",
         confirmPassword: "SecurePass123!",
       };
@@ -269,7 +266,6 @@ describe("User Validations", () => {
       for (const weakPassword of weakPasswords) {
         const invalidData = {
           userId: "123e4567-e89b-12d3-a456-426614174000",
-          isCurrentUser: false,
           newPassword: weakPassword,
           confirmPassword: weakPassword,
         };
@@ -289,7 +285,6 @@ describe("User Validations", () => {
       for (const strongPassword of strongPasswords) {
         const validData = {
           userId: "123e4567-e89b-12d3-a456-426614174000",
-          isCurrentUser: false,
           newPassword: strongPassword,
           confirmPassword: strongPassword,
         };
@@ -308,6 +303,17 @@ describe("User Validations", () => {
 
       const result = UpdateUserPasswordSchema.safeParse(incompleteData);
       expect(result.success).toBe(false);
+    });
+
+    it("should not require client-provided current user state", () => {
+      const formData = {
+        userId: "123e4567-e89b-12d3-a456-426614174000",
+        newPassword: "SecurePass123!",
+        confirmPassword: "SecurePass123!",
+      };
+
+      const result = UpdateUserPasswordSchema.safeParse(formData);
+      expect(result.success).toBe(true);
     });
   });
 

--- a/src/app/api/user/validations.ts
+++ b/src/app/api/user/validations.ts
@@ -34,7 +34,6 @@ export const DeleteUserSchema = z.object({
 export const UpdateUserPasswordSchema = z
   .object({
     userId: z.string().uuid("Invalid user ID"),
-    isCurrentUser: z.boolean(),
     newPassword: passwordSchema,
     confirmPassword: passwordSchema,
     currentPassword: z.string().optional(),
@@ -44,12 +43,6 @@ export const UpdateUserPasswordSchema = z
       ctx.addIssue({
         code: "custom",
         message: UpdateUserPasswordError.PASSWORD_MISMATCH,
-      });
-    }
-    if (data.isCurrentUser && !data.currentPassword) {
-      ctx.addIssue({
-        code: "custom",
-        message: UpdateUserPasswordError.CURRENT_PASSWORD_REQUIRED,
       });
     }
   });


### PR DESCRIPTION
Fixes password reset failing with `Invalid input: Expected boolean, received undefined`.

Both admin password resets for another user and users changing their own password were failing because the server validation expected an `isCurrentUser` boolean from the form payload. The form does not submit that field, so validation failed before the password update logic could run.

The server now derives whether the target user is the current authenticated user from the session instead of trusting a client-provided boolean. This makes both password reset flows work from the same form payload and keeps the current-user password change path protected by server-side identity checks.

Added coverage for reset password submissions without client-provided current-user state.

<img width="1010" height="592" alt="image" src="https://github.com/user-attachments/assets/98f24f71-8240-45e9-a512-7d4acfcb9077" />

<img width="1012" height="700" alt="image" src="https://github.com/user-attachments/assets/37d25efc-3127-45b0-93cf-30f8c4b40519" />
