### PR TITLE
Feat/add litellm provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,13 @@ OLLAMA_BASE_URL=http://localhost:11434/api
 GROQ_API_KEY=****
 GROQ_BASE_URL=https://api.groq.com/openai/v1
 
+# LiteLLM Proxy - unified gateway for 100+ LLM providers (https://docs.litellm.ai)
+# Set LITELLM_BASE_URL to your proxy address and list the models configured on the proxy.
+# Example: LITELLM_MODELS=anthropic/claude-sonnet-4-6,openai/gpt-4o,deepseek/deepseek-chat
+LITELLM_BASE_URL=
+LITELLM_API_KEY=
+LITELLM_MODELS=
+
 
 # (Optional) Default model to use when none is specified
 # Format: provider/model (e.g., openRouter/qwen3-8b:free)

--- a/src/app/api/chat/models/route.ts
+++ b/src/app/api/chat/models/route.ts
@@ -1,8 +1,34 @@
 import { customModelProvider } from "lib/ai/models";
+import { fetchLiteLLMModelList } from "lib/ai/litellm";
 
 export const GET = async () => {
+  const modelsInfo = [...customModelProvider.modelsInfo];
+
+  const litellmEntry = modelsInfo.find((p) => p.provider === "litellm");
+  if (!litellmEntry || litellmEntry.models.length === 0) {
+    const discovered = await fetchLiteLLMModelList();
+    if (discovered.length > 0) {
+      const idx = modelsInfo.findIndex((p) => p.provider === "litellm");
+      const entry = {
+        provider: "litellm",
+        models: discovered.map((m) => ({
+          name: m.name,
+          isToolCallUnsupported: false,
+          isImageInputUnsupported: true,
+          supportedFileMimeTypes: [] as string[],
+        })),
+        hasAPIKey: true,
+      };
+      if (idx >= 0) {
+        modelsInfo[idx] = entry;
+      } else {
+        modelsInfo.push(entry);
+      }
+    }
+  }
+
   return Response.json(
-    customModelProvider.modelsInfo.sort((a, b) => {
+    modelsInfo.sort((a, b) => {
       if (a.hasAPIKey && !b.hasAPIKey) return -1;
       if (!a.hasAPIKey && b.hasAPIKey) return 1;
       return 0;

--- a/src/components/ui/litellm-icon.tsx
+++ b/src/components/ui/litellm-icon.tsx
@@ -1,0 +1,18 @@
+export function LiteLLMIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      className={className}
+    >
+      <path
+        d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/src/components/ui/model-provider-icon.tsx
+++ b/src/components/ui/model-provider-icon.tsx
@@ -5,6 +5,7 @@ import { GrokIcon } from "./grok-icon";
 import { OpenAIIcon } from "./openai-icon";
 import { OllamaIcon } from "./ollama-icon";
 import { OpenRouterIcon } from "./open-router-icon";
+import { LiteLLMIcon } from "./litellm-icon";
 
 export function ModelProviderIcon({
   provider,
@@ -22,6 +23,8 @@ export function ModelProviderIcon({
     <OllamaIcon className={className} />
   ) : provider === "openRouter" ? (
     <OpenRouterIcon className={className} />
+  ) : provider === "litellm" ? (
+    <LiteLLMIcon className={className} />
   ) : (
     <BlendIcon className={className} />
   );

--- a/src/lib/ai/litellm.test.ts
+++ b/src/lib/ai/litellm.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
-import { createLiteLLMModels } from "./litellm";
+import {
+  createLiteLLMModels,
+  getLiteLLMModel,
+  fetchLiteLLMModelList,
+} from "./litellm";
 
 vi.mock("@ai-sdk/openai-compatible", () => ({
   createOpenAICompatible: vi.fn(() =>
@@ -95,5 +99,82 @@ describe("createLiteLLMModels", () => {
         baseURL: "http://localhost:4000/v1",
       }),
     );
+  });
+});
+
+describe("getLiteLLMModel", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns null when LITELLM_BASE_URL is not set", () => {
+    vi.stubEnv("LITELLM_BASE_URL", "");
+    expect(getLiteLLMModel("test")).toBeNull();
+  });
+
+  it("creates model on the fly when configured", () => {
+    vi.stubEnv("LITELLM_BASE_URL", "http://localhost:4000");
+    const model = getLiteLLMModel("anthropic/claude-sonnet-4-6");
+    expect(model).toBeTruthy();
+    expect((model as any).apiName).toBe("anthropic/claude-sonnet-4-6");
+  });
+});
+
+describe("fetchLiteLLMModelList", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("returns empty array when LITELLM_BASE_URL is not set", async () => {
+    vi.stubEnv("LITELLM_BASE_URL", "");
+    const result = await fetchLiteLLMModelList();
+    expect(result).toEqual([]);
+  });
+
+  it("parses /v1/models response correctly", async () => {
+    vi.stubEnv("LITELLM_BASE_URL", "http://localhost:4000");
+    vi.stubEnv("LITELLM_API_KEY", "sk-test");
+
+    const mockResponse = {
+      data: [
+        { id: "anthropic/claude-sonnet-4-6", object: "model" },
+        { id: "gpt-4o", object: "model" },
+      ],
+    };
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    const result = await fetchLiteLLMModelList();
+
+    expect(result).toEqual([
+      { name: "claude-sonnet-4-6", modelId: "anthropic/claude-sonnet-4-6" },
+      { name: "gpt-4o", modelId: "gpt-4o" },
+    ]);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://localhost:4000/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer sk-test",
+        }),
+      }),
+    );
+  });
+
+  it("returns empty array on fetch error", async () => {
+    vi.stubEnv("LITELLM_BASE_URL", "http://localhost:4000");
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+
+    const result = await fetchLiteLLMModelList();
+    expect(result).toEqual([]);
   });
 });

--- a/src/lib/ai/litellm.test.ts
+++ b/src/lib/ai/litellm.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { createLiteLLMModels } from "./litellm";
+
+vi.mock("@ai-sdk/openai-compatible", () => ({
+  createOpenAICompatible: vi.fn(() =>
+    vi.fn((apiName: string) => ({ apiName })),
+  ),
+}));
+
+describe("createLiteLLMModels", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns empty object when LITELLM_BASE_URL is not set", () => {
+    vi.stubEnv("LITELLM_BASE_URL", "");
+    vi.stubEnv("LITELLM_MODELS", "model-a,model-b");
+
+    const result = createLiteLLMModels();
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object when LITELLM_MODELS is not set", () => {
+    vi.stubEnv("LITELLM_BASE_URL", "http://localhost:4000");
+    vi.stubEnv("LITELLM_MODELS", "");
+
+    const result = createLiteLLMModels();
+    expect(result).toEqual({});
+  });
+
+  it("creates models from comma-separated LITELLM_MODELS", () => {
+    vi.stubEnv("LITELLM_BASE_URL", "http://localhost:4000");
+    vi.stubEnv("LITELLM_API_KEY", "sk-test");
+    vi.stubEnv(
+      "LITELLM_MODELS",
+      "anthropic/claude-sonnet-4-6,openai/gpt-4o,deepseek-chat",
+    );
+
+    const result = createLiteLLMModels();
+
+    expect(result).toHaveProperty("claude-sonnet-4-6");
+    expect(result).toHaveProperty("gpt-4o");
+    expect(result).toHaveProperty("deepseek-chat");
+    expect(Object.keys(result)).toHaveLength(3);
+  });
+
+  it("strips provider prefix for display names", () => {
+    vi.stubEnv("LITELLM_BASE_URL", "http://localhost:4000");
+    vi.stubEnv("LITELLM_MODELS", "anthropic/claude-sonnet-4-6");
+
+    const result = createLiteLLMModels();
+    expect(result).toHaveProperty("claude-sonnet-4-6");
+    expect(result).not.toHaveProperty("anthropic/claude-sonnet-4-6");
+  });
+
+  it("handles models without provider prefix", () => {
+    vi.stubEnv("LITELLM_BASE_URL", "http://localhost:4000");
+    vi.stubEnv("LITELLM_MODELS", "deepseek-chat");
+
+    const result = createLiteLLMModels();
+    expect(result).toHaveProperty("deepseek-chat");
+  });
+
+  it("trims whitespace around model ids", () => {
+    vi.stubEnv("LITELLM_BASE_URL", "http://localhost:4000");
+    vi.stubEnv("LITELLM_MODELS", " model-a , model-b ");
+
+    const result = createLiteLLMModels();
+    expect(result).toHaveProperty("model-a");
+    expect(result).toHaveProperty("model-b");
+  });
+
+  it("appends /v1 to base URL when not present", () => {
+    vi.stubEnv("LITELLM_BASE_URL", "http://localhost:4000");
+    vi.stubEnv("LITELLM_MODELS", "test-model");
+
+    createLiteLLMModels();
+
+    expect(createOpenAICompatible).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: "http://localhost:4000/v1",
+      }),
+    );
+  });
+
+  it("does not double-append /v1 when already present", () => {
+    vi.stubEnv("LITELLM_BASE_URL", "http://localhost:4000/v1");
+    vi.stubEnv("LITELLM_MODELS", "test-model");
+
+    createLiteLLMModels();
+
+    expect(createOpenAICompatible).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: "http://localhost:4000/v1",
+      }),
+    );
+  });
+});

--- a/src/lib/ai/litellm.ts
+++ b/src/lib/ai/litellm.ts
@@ -1,0 +1,40 @@
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import type { LanguageModel } from "ai";
+import logger from "logger";
+
+function toDisplayName(modelId: string): string {
+  return modelId.includes("/") ? modelId.split("/").pop()! : modelId;
+}
+
+export function createLiteLLMModels(): Record<string, LanguageModel> {
+  const baseUrl = process.env.LITELLM_BASE_URL;
+  const apiKey = process.env.LITELLM_API_KEY;
+  const modelsEnv = process.env.LITELLM_MODELS;
+
+  if (!baseUrl || !modelsEnv) return {};
+
+  try {
+    const sdkBaseUrl = baseUrl.endsWith("/v1") ? baseUrl : `${baseUrl}/v1`;
+
+    const provider = createOpenAICompatible({
+      name: "litellm",
+      baseURL: sdkBaseUrl,
+      apiKey: apiKey ?? "",
+    });
+
+    const modelIds = modelsEnv
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+
+    const models: Record<string, LanguageModel> = {};
+    for (const id of modelIds) {
+      models[toDisplayName(id)] = provider(id);
+    }
+
+    return models;
+  } catch (error) {
+    logger.error("Failed to create LiteLLM models:", error);
+    return {};
+  }
+}

--- a/src/lib/ai/litellm.ts
+++ b/src/lib/ai/litellm.ts
@@ -2,26 +2,54 @@ import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import type { LanguageModel } from "ai";
 import logger from "logger";
 
+interface LiteLLMModelEntry {
+  id: string;
+  object: string;
+}
+
+interface LiteLLMModelsResponse {
+  data: LiteLLMModelEntry[];
+}
+
+function getBaseUrl(): string | undefined {
+  return process.env.LITELLM_BASE_URL;
+}
+
+function getSdkBaseUrl(baseUrl: string): string {
+  return baseUrl.endsWith("/v1") ? baseUrl : `${baseUrl}/v1`;
+}
+
 function toDisplayName(modelId: string): string {
   return modelId.includes("/") ? modelId.split("/").pop()! : modelId;
 }
 
+let cachedProvider: ReturnType<typeof createOpenAICompatible> | null = null;
+let cachedBaseUrl: string | null = null;
+
+function getOrCreateProvider() {
+  const baseUrl = getBaseUrl();
+  if (!baseUrl) return null;
+  if (cachedProvider && cachedBaseUrl === baseUrl) return cachedProvider;
+
+  cachedBaseUrl = baseUrl;
+  cachedProvider = createOpenAICompatible({
+    name: "litellm",
+    baseURL: getSdkBaseUrl(baseUrl),
+    apiKey: process.env.LITELLM_API_KEY ?? "",
+  });
+  return cachedProvider;
+}
+
 export function createLiteLLMModels(): Record<string, LanguageModel> {
-  const baseUrl = process.env.LITELLM_BASE_URL;
-  const apiKey = process.env.LITELLM_API_KEY;
+  const baseUrl = getBaseUrl();
   const modelsEnv = process.env.LITELLM_MODELS;
 
   if (!baseUrl || !modelsEnv) return {};
 
+  const provider = getOrCreateProvider();
+  if (!provider) return {};
+
   try {
-    const sdkBaseUrl = baseUrl.endsWith("/v1") ? baseUrl : `${baseUrl}/v1`;
-
-    const provider = createOpenAICompatible({
-      name: "litellm",
-      baseURL: sdkBaseUrl,
-      apiKey: apiKey ?? "",
-    });
-
     const modelIds = modelsEnv
       .split(",")
       .map((id) => id.trim())
@@ -31,10 +59,54 @@ export function createLiteLLMModels(): Record<string, LanguageModel> {
     for (const id of modelIds) {
       models[toDisplayName(id)] = provider(id);
     }
-
     return models;
   } catch (error) {
     logger.error("Failed to create LiteLLM models:", error);
     return {};
+  }
+}
+
+export function getLiteLLMModel(modelName: string): LanguageModel | null {
+  const provider = getOrCreateProvider();
+  if (!provider) return null;
+  return provider(modelName);
+}
+
+export interface LiteLLMModelInfo {
+  name: string;
+  modelId: string;
+}
+
+export async function fetchLiteLLMModelList(): Promise<LiteLLMModelInfo[]> {
+  const baseUrl = getBaseUrl();
+  if (!baseUrl) return [];
+
+  try {
+    const modelsUrl = `${getSdkBaseUrl(baseUrl)}/models`;
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    const apiKey = process.env.LITELLM_API_KEY;
+    if (apiKey) {
+      headers.Authorization = `Bearer ${apiKey}`;
+    }
+
+    const response = await fetch(modelsUrl, { headers });
+    if (!response.ok) {
+      logger.error(
+        `LiteLLM /v1/models returned ${response.status}: ${response.statusText}`,
+      );
+      return [];
+    }
+
+    const body = (await response.json()) as LiteLLMModelsResponse;
+    return (body.data ?? [])
+      .map((m) => m.id)
+      .filter(Boolean)
+      .map((id) => ({ name: toDisplayName(id), modelId: id }));
+  } catch (error) {
+    logger.error("Failed to fetch LiteLLM models:", error);
+    return [];
   }
 }

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -12,6 +12,7 @@ import {
   createOpenAICompatibleModels,
   openaiCompatibleModelsSafeParse,
 } from "./create-openai-compatiable";
+import { createLiteLLMModels } from "./litellm";
 import { ChatModel } from "app-types/chat";
 import {
   DEFAULT_FILE_PART_MIME_TYPES,
@@ -160,7 +161,13 @@ const {
   unsupportedModels: openaiCompatibleUnsupportedModels,
 } = createOpenAICompatibleModels(openaiCompatibleProviders);
 
-const allModels = { ...openaiCompatibleModels, ...staticModels };
+const litellmModels = createLiteLLMModels();
+
+const allModels = {
+  ...openaiCompatibleModels,
+  ...staticModels,
+  ...({ litellm: litellmModels } as typeof openaiCompatibleModels),
+};
 
 const allUnsupportedModels = new Set([
   ...openaiCompatibleUnsupportedModels,
@@ -190,7 +197,7 @@ export const customModelProvider = {
       isImageInputUnsupported: isImageInputUnsupportedModel(model),
       supportedFileMimeTypes: [...getFilePartSupportedMimeTypes(model)],
     })),
-    hasAPIKey: checkProviderAPIKey(provider as keyof typeof staticModels),
+    hasAPIKey: checkProviderAPIKey(provider),
   })),
   getModel: (model?: ChatModel): LanguageModel => {
     if (!model) return fallbackModel;
@@ -198,7 +205,7 @@ export const customModelProvider = {
   },
 };
 
-function checkProviderAPIKey(provider: keyof typeof staticModels) {
+function checkProviderAPIKey(provider: string) {
   let key: string | undefined;
   switch (provider) {
     case "openai":
@@ -219,8 +226,11 @@ function checkProviderAPIKey(provider: keyof typeof staticModels) {
     case "openRouter":
       key = process.env.OPENROUTER_API_KEY;
       break;
+    case "litellm":
+      key = process.env.LITELLM_BASE_URL;
+      break;
     default:
-      return true; // assume the provider has an API key
+      return true;
   }
   return !!key && key != "****";
 }

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -12,7 +12,7 @@ import {
   createOpenAICompatibleModels,
   openaiCompatibleModelsSafeParse,
 } from "./create-openai-compatiable";
-import { createLiteLLMModels } from "./litellm";
+import { createLiteLLMModels, getLiteLLMModel } from "./litellm";
 import { ChatModel } from "app-types/chat";
 import {
   DEFAULT_FILE_PART_MIME_TYPES,
@@ -201,7 +201,12 @@ export const customModelProvider = {
   })),
   getModel: (model?: ChatModel): LanguageModel => {
     if (!model) return fallbackModel;
-    return allModels[model.provider]?.[model.model] || fallbackModel;
+    const found = allModels[model.provider]?.[model.model];
+    if (found) return found;
+    if (model.provider === "litellm") {
+      return getLiteLLMModel(model.model) ?? fallbackModel;
+    }
+    return fallbackModel;
   },
 };
 


### PR DESCRIPTION
## Summary
- Adds [LiteLLM](https://github.com/BerriAI/litellm) as a first-class AI gateway provider, giving users access to 100+ LLM providers (AWS Bedrock, Azure, Vertex AI, Anthropic, etc.) through a single proxy endpoint.


## Motivation
Users running a LiteLLM proxy can currently connect via the generic OpenAI-compatible provider, but it requires manually constructing a JSON blob with every model name, API name, and tool-support flag. This PR adds a dedicated LiteLLM provider that:
1. **Auto-discovers models** from the proxy's `/v1/models` endpoint (no manual model listing required)
2. **Falls back to env-var config** via `LITELLM_MODELS` for offline/air-gapped setups
3. Shows up with its own icon in the model picker

## Changes
- `src/lib/ai/litellm.ts` - LiteLLM provider with auto-discovery (`fetchLiteLLMModelList`) + sync env-var mode (`createLiteLLMModels`) + on-the-fly model creation (`getLiteLLMModel`)
- `src/lib/ai/litellm.test.ts` - 13 unit tests covering env parsing, model creation, URL normalization, `/v1/models` fetch, error handling
- `src/lib/ai/models.ts` - registered LiteLLM in model provider registry + API key check + on-the-fly model lookup fallback
- `src/app/api/chat/models/route.ts` - async auto-discovery from LiteLLM proxy's `/v1/models` endpoint
- `src/components/ui/litellm-icon.tsx` - provider icon
- `src/components/ui/model-provider-icon.tsx` - added litellm case
- `.env.example` - documented env vars

## Tests

**1. Unit tests (13/13 pass):**
```
 ✓ src/lib/ai/litellm.test.ts (13 tests)
   ✓ createLiteLLMModels > returns empty object when LITELLM_BASE_URL is not set
   ✓ createLiteLLMModels > returns empty object when LITELLM_MODELS is not set
   ✓ createLiteLLMModels > creates models from comma-separated LITELLM_MODELS
   ✓ createLiteLLMModels > strips provider prefix for display names
   ✓ createLiteLLMModels > handles models without provider prefix
   ✓ createLiteLLMModels > trims whitespace around model ids
   ✓ createLiteLLMModels > appends /v1 to base URL when not present
   ✓ createLiteLLMModels > does not double-append /v1 when already present
   ✓ getLiteLLMModel > returns null when LITELLM_BASE_URL is not set
   ✓ getLiteLLMModel > creates model on the fly when configured
   ✓ fetchLiteLLMModelList > returns empty array when LITELLM_BASE_URL is not set
   ✓ fetchLiteLLMModelList > parses /v1/models response correctly
   ✓ fetchLiteLLMModelList > returns empty array on fetch error
```

**2. Full suite green (418/418):**
```
Test Files  39 passed (39)
     Tests  418 passed (418)
```

**3. Lint + types clean:**
```
biome lint - Checked 547 files. No fixes applied.
tsc --noEmit - clean
```

**4. Live E2E against LiteLLM proxy (Azure Foundry -> Claude Sonnet 4.6):**
```
=== LiteLLM E2E Test via Vercel AI SDK ===

1. Fetching models from http://localhost:4000/v1/models ...
   Discovered models: ["claude-sonnet-4-6"]

2. Sending chat completion to model: claude-sonnet-4-6
   Response: "4"
   Finish reason: stop
   Usage: {"inputTokens":20,"outputTokens":5,"totalTokens":25,"cachedInputTokens":0}

=== E2E Test PASSED ===
```
Full chain: `createOpenAICompatible` -> LiteLLM proxy -> Azure Foundry (Claude Sonnet 4.6) -> response parsed through Vercel AI SDK.

## Risk / Compatibility
- Additive only. No existing providers or tests modified.
- Uses `@ai-sdk/openai-compatible` which is already a project dependency - zero new deps.
- When `LITELLM_BASE_URL` is unset, the provider is completely inert.

## Example usage

**Option A: Auto-discovery (recommended)**
```env
# .env - just point at your proxy, models are discovered automatically
LITELLM_BASE_URL=http://localhost:4000
LITELLM_API_KEY=sk-your-proxy-key
```

**Option B: Explicit model list (air-gapped / offline)**
```env
# .env - list models manually when proxy is not reachable at startup
LITELLM_BASE_URL=http://localhost:4000
LITELLM_API_KEY=sk-your-proxy-key
LITELLM_MODELS=anthropic/claude-sonnet-4-6,openai/gpt-4o,deepseek/deepseek-chat
```

Models appear in the model picker under the "litellm" provider group.
