### PR TITLE
fix: tread name sometimes do not persist

### DIFF
--- a/src/app/api/chat/title/route.ts
+++ b/src/app/api/chat/title/route.ts
@@ -42,14 +42,15 @@ export async function POST(request: Request) {
       experimental_transform: smoothStream({ chunking: "word" }),
       prompt: message,
       abortSignal: request.signal,
-      onFinish: (ctx) => {
-        chatRepository
-          .upsertThread({
-            id: threadId,
-            title: ctx.text,
-            userId: session.user.id,
-          })
-          .catch((err) => logger.error(err));
+      onFinish: async (ctx) => {
+        const title = ctx.text.trim();
+        if (!title) return;
+
+        await chatRepository.upsertThread({
+          id: threadId,
+          title,
+          userId: session.user.id,
+        });
       },
     });
 

--- a/src/hooks/queries/use-generate-thread-title.ts
+++ b/src/hooks/queries/use-generate-thread-title.ts
@@ -18,7 +18,7 @@ export function useGenerateThreadTitle(option: {
   const updateTitle = useCallback(
     (title: string) => {
       appStore.setState((prev) => {
-        if (prev.threadList.some((v) => v.id !== option.threadId)) {
+        if (!prev.threadList.some((v) => v.id === option.threadId)) {
           return {
             threadList: [
               {


### PR DESCRIPTION
Fix 
- not awaited promise to set the thread title,
- and fix exists-check to ensure no duplicates saved.

Current impl works fine in node env but fails in cloud envs where unawaited promises are optimised away.  